### PR TITLE
III-4689 Add custom `invalid-workflow-status-transition` error type

### DIFF
--- a/projects/uitdatabank/docs/errors.md
+++ b/projects/uitdatabank/docs/errors.md
@@ -69,3 +69,11 @@ Example error response:
   "label": "reserved_label_example"
 }
 ```
+
+## invalid-workflow-status-transition
+
+*   **Complete type:** `https://api.publiq.be/probs/uitdatabank/invalid-workflow-status-transition`
+*   **Title**: `Invalid workflowStatus transition`
+*   **Status**: `400`
+
+The `workflowStatus` of an event can only transition from `DRAFT` to `READY_FOR_VALIDATION`, from `READY_FOR_VALIDATION` to either `APPROVED` or `REJECTED`, or from any workflowStatus to `DELETED`. Other transitions are not possible, for example back from `REJECTED` to `READY_FOR_VALIDATION`.


### PR DESCRIPTION
### Added

- Added custom `invalid-workflow-status-transition` error type for workflowStatus transitions that are not supported. (Needed in III-4689 to return a correct error response when trying to publish a rejected or deleted offer)

---

Ticket: https://jira.uitdatabank.be/browse/III-4689
