### PR TITLE
III-4761 + III-4762 Event/place example tweaks

### DIFF
--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -230,6 +230,15 @@
                         "inLanguage": "nl"
                       }
                     ],
+                    "videos": [
+                      {
+                        "id": "b504cf44-9ab8-4641-9934-38d1cc67242c",
+                        "url": "https://www.youtube.com/watch?v=cEItmb_a20D",
+                        "embedUrl": "https://www.youtube.com/embed/cEItmb_a20D",
+                        "language": "nl",
+                        "copyrightHolder": "publiq"
+                      }
+                    ],
                     "labels": [
                       "label1"
                     ],

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -503,6 +503,15 @@
                         "inLanguage": "nl"
                       }
                     ],
+                    "videos": [
+                      {
+                        "id": "b504cf44-9ab8-4641-9934-38d1cc67242c",
+                        "url": "https://www.youtube.com/watch?v=cEItmb_a20D",
+                        "embedUrl": "https://www.youtube.com/embed/cEItmb_a20D",
+                        "language": "nl",
+                        "copyrightHolder": "publiq"
+                      }
+                    ],
                     "labels": [
                       "label1"
                     ],

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -2770,15 +2770,6 @@
                     "calendarType": "periodic",
                     "startDate": "2021-05-17T22:00:00+00:00",
                     "endDate": "2021-05-17T22:00:00+00:00",
-                    "status": {
-                      "type": "Available",
-                      "reason": {
-                        "nl": "Nederlandse reden",
-                        "fr": "Raison français",
-                        "de": "Deutscher Grund",
-                        "en": "English reason"
-                      }
-                    },
                     "openingHours": [
                       {
                         "opens": "17:00",
@@ -2866,10 +2857,7 @@
                     ],
                     "hiddenLabels": [
                       "label2"
-                    ],
-                    "bookingAvailability": {
-                      "type": "Available"
-                    }
+                    ]
                   }
                 }
               }

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -138,15 +138,6 @@
                     "calendarType": "single",
                     "startDate": "2021-05-17T22:00:00+00:00",
                     "endDate": "2021-05-17T22:00:00+00:00",
-                    "status": {
-                      "type": "Available",
-                      "reason": {
-                        "nl": "Nederlandse reden",
-                        "fr": "Raison français",
-                        "de": "Deutscher Grund",
-                        "en": "English reason"
-                      }
-                    },
                     "subEvent": [
                       {
                         "id": 0,
@@ -244,10 +235,7 @@
                     ],
                     "hiddenLabels": [
                       "label2"
-                    ],
-                    "bookingAvailability": {
-                      "type": "Available"
-                    }
+                    ]
                   }
                 }
               }

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -158,7 +158,6 @@
                       }
                     ],
                     "availableFrom": "2021-05-17T22:00:00+00:00",
-                    "availableTo": "2021-05-17T22:00:00+00:00",
                     "location": {
                       "@id": "https://io-test.uitdatabank.be/places/85b04295-479c-40f5-b3dd-469dfb4387b3"
                     },
@@ -434,7 +433,6 @@
                       }
                     ],
                     "availableFrom": "2021-05-17T22:00:00+00:00",
-                    "availableTo": "2021-05-17T22:00:00+00:00",
                     "location": {
                       "@id": "https://io-test.uitdatabank.be/places/85b04295-479c-40f5-b3dd-469dfb4387b3"
                     },
@@ -2798,7 +2796,6 @@
                       }
                     ],
                     "availableFrom": "2021-05-17T22:00:00+00:00",
-                    "availableTo": "2021-05-17T22:00:00+00:00",
                     "terms": [
                       {
                         "id": "0.14.0.0.0",
@@ -3081,7 +3078,6 @@
                       }
                     ],
                     "availableFrom": "2021-05-17T22:00:00+00:00",
-                    "availableTo": "2021-05-17T22:00:00+00:00",
                     "terms": [
                       {
                         "id": "0.14.0.0.0",

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -399,9 +399,6 @@
                       "de": "Deutscher Name",
                       "en": "English name"
                     },
-                    "calendarType": "single",
-                    "startDate": "2021-05-17T22:00:00+00:00",
-                    "endDate": "2021-05-17T22:00:00+00:00",
                     "status": {
                       "type": "Available",
                       "reason": {
@@ -411,6 +408,12 @@
                         "en": "English reason"
                       }
                     },
+                    "bookingAvailability": {
+                      "type": "Available"
+                    },
+                    "calendarType": "single",
+                    "startDate": "2021-05-17T22:00:00+00:00",
+                    "endDate": "2021-05-17T22:00:00+00:00",
                     "subEvent": [
                       {
                         "id": 0,
@@ -517,10 +520,7 @@
                     ],
                     "hiddenLabels": [
                       "label2"
-                    ],
-                    "bookingAvailability": {
-                      "type": "Available"
-                    }
+                    ]
                   }
                 }
               }
@@ -3056,9 +3056,6 @@
                         "streetAddress": "Wetstraat 1"
                       }
                     },
-                    "calendarType": "periodic",
-                    "startDate": "2021-05-17T22:00:00+00:00",
-                    "endDate": "2021-05-17T22:00:00+00:00",
                     "status": {
                       "type": "Available",
                       "reason": {
@@ -3068,6 +3065,12 @@
                         "en": "English reason"
                       }
                     },
+                    "bookingAvailability": {
+                      "type": "Available"
+                    },
+                    "calendarType": "periodic",
+                    "startDate": "2021-05-17T22:00:00+00:00",
+                    "endDate": "2021-05-17T22:00:00+00:00",
                     "openingHours": [
                       {
                         "opens": "17:00",
@@ -3155,10 +3158,7 @@
                     ],
                     "hiddenLabels": [
                       "label2"
-                    ],
-                    "bookingAvailability": {
-                      "type": "Available"
-                    }
+                    ]
                   }
                 }
               }


### PR DESCRIPTION
### Added

- Added missing `videos` to event create/update examples

### Changed

- Grouped `status` and `bookingAvailability` together in event and place update examples because they have a high cohesion functionally

### Removed

- Removed `status` and `bookingAvailability` from event/place create examples because they are usually not used when creating events/places, but only set later (see ticket description)
- Removed `availableTo` from event/place create & update examples, because it's a read-only property that gets derived from the calendar info. So it is not useful to include it in create/update requests.

---

Ticket: https://jira.uitdatabank.be/browse/III-4761 + https://jira.uitdatabank.be/browse/III-4762
