### PR TITLE
III-4761 Event create/update example tweaks

### DIFF
--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -401,7 +401,7 @@
                         "startDate": "2021-05-17T22:00:00+00:00",
                         "endDate": "2021-05-17T22:00:00+00:00",
                         "status": {
-                          "type": "Available",
+                          "type": "Unavailable",
                           "reason": {
                             "nl": "Nederlandse reden",
                             "fr": "Raison français",
@@ -410,7 +410,7 @@
                           }
                         },
                         "bookingAvailability": {
-                          "type": "Available"
+                          "type": "Unavailable"
                         }
                       }
                     ],
@@ -3036,7 +3036,7 @@
                       }
                     },
                     "status": {
-                      "type": "Available",
+                      "type": "Unavailable",
                       "reason": {
                         "nl": "Nederlandse reden",
                         "fr": "Raison français",
@@ -3045,7 +3045,7 @@
                       }
                     },
                     "bookingAvailability": {
-                      "type": "Available"
+                      "type": "Unavailable"
                     },
                     "calendarType": "periodic",
                     "startDate": "2021-05-17T22:00:00+00:00",

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -136,8 +136,6 @@
                       "en": "English name"
                     },
                     "calendarType": "single",
-                    "startDate": "2021-05-17T22:00:00+00:00",
-                    "endDate": "2021-05-17T22:00:00+00:00",
                     "subEvent": [
                       {
                         "id": 0,

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -142,19 +142,7 @@
                       {
                         "id": 0,
                         "startDate": "2021-05-17T22:00:00+00:00",
-                        "endDate": "2021-05-17T22:00:00+00:00",
-                        "status": {
-                          "type": "Available",
-                          "reason": {
-                            "nl": "Nederlandse reden",
-                            "fr": "Raison français",
-                            "de": "Deutscher Grund",
-                            "en": "English reason"
-                          }
-                        },
-                        "bookingAvailability": {
-                          "type": "Available"
-                        }
+                        "endDate": "2021-05-17T22:00:00+00:00"
                       }
                     ],
                     "availableFrom": "2021-05-17T22:00:00+00:00",

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -138,7 +138,6 @@
                     "calendarType": "single",
                     "subEvent": [
                       {
-                        "id": 0,
                         "startDate": "2021-05-17T22:00:00+00:00",
                         "endDate": "2021-05-17T22:00:00+00:00"
                       }

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -397,11 +397,8 @@
                       "type": "Available"
                     },
                     "calendarType": "single",
-                    "startDate": "2021-05-17T22:00:00+00:00",
-                    "endDate": "2021-05-17T22:00:00+00:00",
                     "subEvent": [
                       {
-                        "id": 0,
                         "startDate": "2021-05-17T22:00:00+00:00",
                         "endDate": "2021-05-17T22:00:00+00:00",
                         "status": {


### PR DESCRIPTION
### Removed

- Removed `status` and `bookingAvailability` from `subEvent` in event create example
- Removed `id` from `subEvent` in event create/update examples (not necessary, derived from the position in the array and only required on the PATCH endpoint for subEvents)
- Removed `startDate` and `endDate` from event in create/update examples (these are derived from the subEvent)

### Changed

- Changed `status` and `bookingAvailability` from `Available` to `Unavailable` in update examples (as that is more usual than updating it to `Available`, especially if a reason is given)

---

Follow-up PR for ticket: https://jira.uitdatabank.be/browse/III-4761
