### PR TITLE
III-4769 Make priceCurrency optional

### DIFF
--- a/projects/uitdatabank/models/common-priceInfo.json
+++ b/projects/uitdatabank/models/common-priceInfo.json
@@ -39,7 +39,7 @@
               "EUR"
             ],
             "default": "EUR",
-            "description": "The currency of the price. Currently only `EUR` is supported.",
+            "description": "The currency of the price. Currently only `EUR` is supported."
           },
           "name": {
             "$ref": "./common-name.json",


### PR DESCRIPTION
### Changed

- Make `priceCurrency` optional, as was the case in the old `price-info` endpoint before the refactor to use JSON schema (it was always required in the imports, but making it optional there is not a breaking change and more consistent behavior)

---

Ticket: https://jira.uitdatabank.be/browse/III-4769
