### PR TITLE
uitpas: larger default limit value for cardsystems

### DIFF
--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -4297,7 +4297,13 @@
             "$ref": "#/components/parameters/start"
           },
           {
-            "$ref": "#/components/parameters/limit"
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            },
+            "description": "Maximum amount of results to return. Can be used in combination with `start` for pagination.",
+            "name": "limit"
           },
           {
             "schema": {


### PR DESCRIPTION
### Changed

- default limit for GET /cardsystems set to 100 instead of 20
