### PR TITLE
API-88 Document how to get client credentials

### DIFF
--- a/projects/authentication/docs/introduction.md
+++ b/projects/authentication/docs/introduction.md
@@ -1,0 +1,9 @@
+# Introduction
+
+This space gives an overview of the possible authentication methods on publiq's APIs.
+
+In the past, almost every one of our APIs used a different authentication method. To provide a consistent experience and reduce the work needed to integrate with multiple of our APIs, we have evolved our APIs to support a shared authentication approach.
+
+To start, you will need a set of client credentials consisting of a **client id** and **client secret** which we will provide you. You can then use these in 3 ways to authenticate your requests to our APIs, depending on the API(s) you integrate with and your function use case. See the [authentication methods overview](./methods.md) for more info about the various ways that you can authenticate your requests.
+
+To request your own set of client credentials, see [requesting client credentials](./requesting-credentials.md).

--- a/projects/authentication/docs/introduction.md
+++ b/projects/authentication/docs/introduction.md
@@ -4,6 +4,6 @@ This space gives an overview of the possible authentication methods on publiq's 
 
 In the past, almost every one of our APIs used a different authentication method. To provide a consistent experience and reduce the work needed to integrate with multiple of our APIs, we have evolved our APIs to support a shared authentication approach.
 
-To start, you will need a set of client credentials consisting of a **client id** and **client secret** which we will provide you. You can then use these in 3 ways to authenticate your requests to our APIs, depending on the API(s) you integrate with and your function use case. See the [authentication methods overview](./methods.md) for more info about the various ways that you can authenticate your requests.
+To start, you will need a set of client credentials consisting of a **client id** and **client secret** which we will provide you. You can then use these in 3 ways to authenticate your requests to our APIs, depending on the API(s) you integrate with and your use case. See the [authentication methods overview](./methods.md) for more info about the various ways that you can authenticate your requests.
 
 To request your own set of client credentials, see [requesting client credentials](./requesting-credentials.md).

--- a/projects/authentication/docs/requesting-credentials.md
+++ b/projects/authentication/docs/requesting-credentials.md
@@ -24,4 +24,4 @@ Aside from the authentication method all API operations work exactly the same wh
 
 ## museumPASSmusées
 
-Access to the [museumPASSmusées Partner API](https://docs.publiq.be/docs/museumpassmusees) is only provided to very specific partners at the moment as the functionality is very specific to museum visits. To request your credentials, please contact support@museumpassmusees.be.
+Access to the [museumPASSmusées Partner API](https://docs.publiq.be/docs/museumpassmusees) is only provided to very specific partners for now as the primary use case at the moment is registering museum visits via a card reader. To request your credentials, please contact support@museumpassmusees.be.

--- a/projects/authentication/docs/requesting-credentials.md
+++ b/projects/authentication/docs/requesting-credentials.md
@@ -10,9 +10,9 @@ To use [UiTPAS API v4](https://docs.publiq.be/docs/uitpas), see its [quickstart 
 
 ## UiTdatabank
 
-UiTdatabank APIs currently uses a custom authentication method based on API keys instead of client ids and secrets.
+UiTdatabank APIs historically use a custom authentication method based on API keys instead of client ids and secrets.
 
-While support for the standardized authentication methods documented in this space has been implemented, new client ids and secrets are only provided to a select few partners that are trying out these new authentication methods in UiTdatabank. In the future this will be opened up to all integrators.
+Support for the standardized authentication methods documented in this space has been implemented, but new client ids and secrets are only provided to a select few partners that are trying out these new authentication methods in UiTdatabank. In the future this will be opened up to all integrators.
 
 Want to start integrating with UiTdatabank right now? There are three options:
 
@@ -20,7 +20,7 @@ Want to start integrating with UiTdatabank right now? There are three options:
 2.  **Or**, contact us at vragen@uitdatabank.be to get a client id and client secret for UiTdatabank to start using the new authentication mechanism already. Once you have your client id and secret you can use the standard authentication methods described here.
 3.  **Or**, register your project at [Projectaanvraag](https://projectaanvraag.uitdatabank.be) to automatically get a test **API key** that you can use as described on the [EntryAPI authentication documentation](https://documentatie.uitdatabank.be/content/entry_api\_3/latest/authentication.html) in our older documentation portal. While this way of authentication will be phased out in the future for new integrators, it will still be supported for existing integrations for the foreseeable future.
 
-Aside from the authentication method all API operations work exactly the same whether you have a client id and secret, or an API key.
+Aside from the authentication method all API operations on the UiTdatabank APIs work exactly the same whether you have a client id and secret, or an API key.
 
 ## museumPASSmusées
 

--- a/projects/authentication/docs/requesting-credentials.md
+++ b/projects/authentication/docs/requesting-credentials.md
@@ -14,10 +14,11 @@ UiTdatabank APIs currently uses a custom authentication method based on API keys
 
 While support for the standardized authentication methods documented in this space has been implemented, new client ids and secrets are only provided to a select few partners that are trying out these new authentication methods in UiTdatabank. In the future this will be opened up to all integrators.
 
-Want to start integrating with UiTdatabank right now? There are two options:
+Want to start integrating with UiTdatabank right now? There are three options:
 
-1.  Contact us at vragen@uitdatabank.be to get a client id and client secret to start using the new authentication mechanism already. Once you have your client id and secret you can use the standard authentication methods described here.
-2.  **Or**, register your project at [Projectaanvraag](https://projectaanvraag.uitdatabank.be) to automatically get a test **API key** that you can use as described on the [EntryAPI authentication documentation](https://documentatie.uitdatabank.be/content/entry_api\_3/latest/authentication.html) in our older documentation portal. While this way of authentication will be phased out in the future for new integrators, it will still be supported for existing integrations for the foreseeable future.
+1.  If you need to integrate with both the **UiTPAS API and UiTdatabank API(s)**, you can follow the procedure of requesting credentials for the UiTPAS API and mention that you also require access to the UiTdatabank APIs. We will then provide you with a set of credentials that can access both.
+2.  **Or**, contact us at vragen@uitdatabank.be to get a client id and client secret for UiTdatabank to start using the new authentication mechanism already. Once you have your client id and secret you can use the standard authentication methods described here.
+3.  **Or**, register your project at [Projectaanvraag](https://projectaanvraag.uitdatabank.be) to automatically get a test **API key** that you can use as described on the [EntryAPI authentication documentation](https://documentatie.uitdatabank.be/content/entry_api\_3/latest/authentication.html) in our older documentation portal. While this way of authentication will be phased out in the future for new integrators, it will still be supported for existing integrations for the foreseeable future.
 
 Aside from the authentication method all API operations work exactly the same whether you have a client id and secret, or an API key.
 

--- a/projects/authentication/docs/requesting-credentials.md
+++ b/projects/authentication/docs/requesting-credentials.md
@@ -4,6 +4,8 @@ Before you can start making authenticated API requests, you need to register you
 
 While we are working on a new self-service platform where you will be able to register your project for any API integration and automatically recieve client credentials in the future, the method to request your credentials currently varies per API as it is handled by multiple teams.
 
+> You may access multiple APIs with the same client credentials, but your project needs to be configured correctly on our side to have permission to access all the APIs you need. So if you require access to multiple APIs, make sure to mention this when requesting the credentials so we can give your client sufficient access permissions.
+
 ## UiTPAS
 
 To use [UiTPAS API v4](https://docs.publiq.be/docs/uitpas), see its [quickstart guide](https://docs.publiq.be/docs/uitpas/d0748f47a3dba-quick-start) to request a client id and client secret via the linked Google Form.

--- a/projects/authentication/docs/requesting-credentials.md
+++ b/projects/authentication/docs/requesting-credentials.md
@@ -1,0 +1,26 @@
+# Requesting client credentials
+
+Before you can start making authenticated API requests, you need to register your integration with us so we can provide you with the necessary credentials.
+
+While we are working on a new self-service platform where you will be able to register your project for any API integration and automatically recieve client credentials in the future, the method to request your credentials currently varies per API as it is handled by multiple teams.
+
+## UiTPAS
+
+To use [UiTPAS API v4](https://docs.publiq.be/docs/uitpas), see its [quickstart guide](https://docs.publiq.be/docs/uitpas/d0748f47a3dba-quick-start) to request a client id and client secret via the linked Google Form.
+
+## UiTdatabank
+
+UiTdatabank APIs currently uses a custom authentication method based on API keys instead of client ids and secrets.
+
+While support for the standardized authentication methods documented in this space has been implemented, new client ids and secrets are only provided to a select few partners that are trying out these new authentication methods in UiTdatabank. In the future this will be opened up to all integrators.
+
+Want to start integrating with UiTdatabank right now? There are two options:
+
+1.  Contact us at vragen@uitdatabank.be to get a client id and client secret to start using the new authentication mechanism already. Once you have your client id and secret you can use the standard authentication methods described here.
+2.  **Or**, register your project at [Projectaanvraag](https://projectaanvraag.uitdatabank.be) to automatically get a test **API key** that you can use as described on the [EntryAPI authentication documentation](https://documentatie.uitdatabank.be/content/entry_api\_3/latest/authentication.html) in our older documentation portal. While this way of authentication will be phased out in the future for new integrators, it will still be supported for existing integrations for the foreseeable future.
+
+Aside from the authentication method all API operations work exactly the same whether you have a client id and secret, or an API key.
+
+## museumPASSmusées
+
+Access to the [museumPASSmusées Partner API](https://docs.publiq.be/docs/museumpassmusees) is only provided to very specific partners at the moment as the functionality is very specific to museum visits. To request your credentials, please contact support@museumpassmusees.be.

--- a/projects/authentication/toc.json
+++ b/projects/authentication/toc.json
@@ -2,6 +2,11 @@
   "items": [
     {
       "type": "item",
+      "title": "Introduction",
+      "uri": "docs/introduction.md"
+    },
+    {
+      "type": "item",
       "title": "Requesting client credentials",
       "uri": "docs/requesting-credentials.md"
     },

--- a/projects/authentication/toc.json
+++ b/projects/authentication/toc.json
@@ -1,6 +1,11 @@
 {
   "items": [
     {
+      "type": "item",
+      "title": "Requesting client credentials",
+      "uri": "docs/requesting-credentials.md"
+    },
+    {
       "type": "divider",
       "title": "Authentication methods"
     },


### PR DESCRIPTION
### Added

- Introduction page
- How to get client credentials

---

Ticket: https://jira.uitdatabank.be/browse/API-88

Note: This PR only focuses on the scope described above. Other improvements to the authentication documentation are coming in different tickets / PRs.

Preview: https://docs.publiq.be/docs/authentication/branches/authentication%2FAPI-88-getting-started/d6a8ba3f3c186-introduction (login with apidocs@publiq.be user required)
