### PR TITLE
API-54 Document requirements per authentication method

### DIFF
--- a/projects/authentication/docs/client-access-token.md
+++ b/projects/authentication/docs/client-access-token.md
@@ -1,10 +1,12 @@
 # Client access token
 
-## Overview
+Client access tokens are used to authenticate API requests from a **backend** system.
 
-Client access tokens are used to secure API endpoints that require more robust authentication than [client identification](./client-identification.md) between two *backend* systems.
+The client can request a token on publiq's authorization server with its client id and client secret, and include this token in API requests until it expires. After the token has expired, the client can simply request a new token in the same way as before. The flow to request a token is a standard [OAuth2 `client_credentials` flow](https://oauth.net/2/grant-types/client-credentials/).
 
-Before accessing an API endpoint like this, a client needs to obtain a client access token using its credentials (the client id and secret) from publiq's authorization server.
+The token serves as proof of identity of the client, in other words your backend system. Because browsers and native applications cannot securely store the necessary client secret, they must not use client access tokens. A possible alternative in this case would be using [user access tokens](./user-access-token.md) with the PKCE flow.
+
+If your browser or native application cannot work with user logins via publiq's UiTID, you may also send requests from your frontend application to your own backend, and make API requests from there with a client access token. Note that you will be responsible to determine who may or may not access your backend to prevent abuse.
 
 ## Requirements
 

--- a/projects/authentication/docs/client-access-token.md
+++ b/projects/authentication/docs/client-access-token.md
@@ -6,6 +6,16 @@ Client access tokens are used to secure API endpoints that require more robust a
 
 Before accessing an API endpoint like this, a client needs to obtain a client access token using its credentials (the client id and secret) from publiq's authorization server.
 
+## Requirements
+
+-   A client id
+-   A client secret
+-   Your API requests are always made from a **backend** system
+
+See [requesting client credentials](./requesting-credentials.md) how to obtain a set of client credentials.
+
+## Flow
+
 1.  The client makes a request to the authorization server with its id and secret.
 
 2.  The authorization server validates the request and, if successful, sends a response with an access token.
@@ -27,7 +37,7 @@ Before accessing an API endpoint like this, a client needs to obtain a client ac
 >
 > Client access tokens are requested using the standardized [OAuth 2.0 Client Credentials Grant](https://oauth.net/2/grant-types/client-credentials/). If you are familiar with this flow, you can skip most of the example flow below. Do check the info about the required `audience` property though.
 
-## Example flow
+## Example
 
 To obtain a client access token, send a `POST` request to the `/oauth/token` endpoint of the authentication server with a JSON body like this:
 

--- a/projects/authentication/docs/client-identification.md
+++ b/projects/authentication/docs/client-identification.md
@@ -10,7 +10,9 @@ You can specify your client id in requests to these APIs in two ways.
 
 -  A client id. See [requesting client credentials](./requesting-credentials.md) how to obtain one.
 
-## Via header
+## Usage
+
+### Via header
 
 You can specify your client id as an `x-client-id` HTTP header. For example on Search API 3:
 
@@ -36,7 +38,7 @@ Fill in your client id in the form below and send your request to try it out!
 }
 ```
 
-## Via query parameter
+### Via query parameter
 
 Alternatively you can specify a `clientId` URL query parameter instead of an HTTP header. For example on Search API 3:
 

--- a/projects/authentication/docs/client-identification.md
+++ b/projects/authentication/docs/client-identification.md
@@ -6,7 +6,7 @@ These APIs only require you to specify the client id of your integration for cus
 
 ## Requirements
 
--  A client id. See [requesting client credentials](./requesting-credentials.md) how to obtain one.
+-   A client id. See [requesting client credentials](./requesting-credentials.md) how to obtain one.
 
 ## Usage
 

--- a/projects/authentication/docs/client-identification.md
+++ b/projects/authentication/docs/client-identification.md
@@ -22,6 +22,8 @@ Host: https://search-test.uitdatabank.be
 X-Client-Id: YrgBoha6aRSrfIcsFt8PISe4u0EoM45k
 ```
 
+Note that the name of the `x-client-id` header is case insensitive, like every header name.
+
 > The `x-client-id` header is useful in code because a lot of HTTP libraries allow you to specify default headers to include in every request, so you do not need to repeat it in multiple places in your code.
 
 #### Try it!

--- a/projects/authentication/docs/client-identification.md
+++ b/projects/authentication/docs/client-identification.md
@@ -4,13 +4,13 @@ Some APIs only expose public information and need to be accessible directly from
 
 These APIs only require you to specify the client id of your integration for customization and technical support purposes. For example your client id can have a custom default query in Search API 3 to always filter out search results that are irrelevant to your integration.
 
-You can specify your client id in requests to these APIs in two ways.
-
 ## Requirements
 
 -  A client id. See [requesting client credentials](./requesting-credentials.md) how to obtain one.
 
 ## Usage
+
+You can include your client id in your requests to our APIs in two ways.
 
 ### Via header
 

--- a/projects/authentication/docs/client-identification.md
+++ b/projects/authentication/docs/client-identification.md
@@ -6,6 +6,10 @@ These APIs only require you to specify the client id of your integration for cus
 
 You can specify your client id in requests to these APIs in two ways.
 
+## Requirements
+
+-  A client id. See [requesting client credentials](./requesting-credentials.md) how to obtain one.
+
 ## Via header
 
 You can specify your client id as an `x-client-id` HTTP header. For example on Search API 3:

--- a/projects/authentication/docs/client-identification.md
+++ b/projects/authentication/docs/client-identification.md
@@ -2,7 +2,7 @@
 
 Some APIs only expose public information and need to be accessible directly from a browser, like UiTdatabank's Search API or the UiTPAS advantages search.
 
-These APIs only require you to specify the client id of your integration for customization and technical support purposes. For example your client id can have a custom default query in Search API 3 to always filter out search results that are irrelevant to your integration.
+These APIs only require you to specify the client id of your integration for customization and technical support purposes.
 
 ## Requirements
 

--- a/projects/authentication/docs/client-identification.md
+++ b/projects/authentication/docs/client-identification.md
@@ -22,7 +22,7 @@ Host: https://search-test.uitdatabank.be
 X-Client-Id: YrgBoha6aRSrfIcsFt8PISe4u0EoM45k
 ```
 
-Using a header can be helpful to only have to set it once depending on the programming language and/or HTTP library you are using. It also reduces the URL size.
+> The `x-client-id` header is useful in code because a lot of HTTP libraries allow you to specify default headers to include in every request, so you do not need to repeat it in multiple places in your code.
 
 #### Try it!
 
@@ -47,7 +47,7 @@ GET /events/?clientId=YrgBoha6aRSrfIcsFt8PISe4u0EoM45k HTTP/1.1
 Host: https://search-test.uitdatabank.be
 ```
 
-Using a query parameter can be helpful for link sharing or when doing quick manual tests.
+> The `?clientId=...` query parameter is mostly useful when doing manual requests, for example in a browser, because you just need to include the client id in the URL that you are requesting.
 
 #### Try it!
 
@@ -62,9 +62,3 @@ Fill in your client id in the form below and send your request to try it out!
   }
 }
 ```
-
-## When to use which method
-
-When using client identification from a **frontend application** it is advisable to use the `clientId` query parameter because using the `x-client-id` header requires [CORS](./cors.md), while using an extra query parameter doesn't.
-
-If you are using client identification on requests from a **backend application**, you can choose whatever method you like best. Using the `x-client-id` header might be easier in some HTTP libraries because you can usually define some global headers that you want to send for every request, but this depends on the programming language and HTTP library.

--- a/projects/authentication/docs/user-access-token.md
+++ b/projects/authentication/docs/user-access-token.md
@@ -50,7 +50,6 @@ Before you can use one of the Authorization Code flows above, your client needs 
 
 *   **Login URI**: The absolute URI of the page where your users will login. For example `https://example.com/login`.
 *   **Callback URL(s)**: The absolute URL(s) of the page(s) where your users can be redirected back to after they log in. You can specify this callback URL whenever you redirect a user to the authorization server to log in, but it needs to be **whitelisted** first to prevent phishing attacks. For example `https://example.com/authorize`.
-*   **Logout URL(s)**: The absolute URL(s) of the page(s) where your users can be redirected back to *after* they log out. This page should also clear any tokens or other session data that you store for the user in your app. You can specify this URL whenever you redirect a user to the authorization server to log out, but it needs to be **whitelisted** first to prevent phishing attacks. For example `https://example.com/logout`.
 
 Additionally, if you want to use the PKCE flow you will also need to specify:
 

--- a/projects/authentication/docs/user-access-token.md
+++ b/projects/authentication/docs/user-access-token.md
@@ -1,7 +1,5 @@
 # User access token
 
-## Overview
-
 User access tokens are used to communicate with a publiq API in the name of a user logged in through UiTID, and can be requested through one of two ways depending on the type of application that you're building.
 
 Both flows are standard [OAuth2](https://oauth.net/2/) flows and work largely the same. In both cases you will redirect the user to the authorization server where they can login. Afterward, the user will be redirected back to your application and you will receive an authorization code. With this code you can request a user access token on the authorization server.

--- a/projects/authentication/docs/user-access-token.md
+++ b/projects/authentication/docs/user-access-token.md
@@ -6,13 +6,8 @@ User access tokens are used to communicate with a publiq API in the name of a us
 
 Both flows are standard [OAuth2](https://oauth.net/2/) flows and work largely the same. In both cases you will redirect the user to the authorization server where they can login. Afterward, the user will be redirected back to your application and you will receive an authorization code. With this code you can request a user access token on the authorization server.
 
-<!-- theme: info -->
+> publiq uses [Auth0](https://auth0.com/) as its authentication and authorization server. As they also provide extensive documentation, we link to their documentation in some places on this page.
 
-> ##### Auth0
->
-> publiq currently uses [Auth0](https://auth0.com/) as the implementation of its authentication and authorization service. Most info can be found in their documentation linked below.
->
-> At the end of this page you can find more info about specific configuration that you will need on publiq's authorization servers, like their domain names.
 
 ### Regular web applications
 

--- a/projects/authentication/docs/user-access-token.md
+++ b/projects/authentication/docs/user-access-token.md
@@ -6,6 +6,27 @@ Both flows are standard [OAuth2](https://oauth.net/2/) flows and work largely th
 
 > publiq uses [Auth0](https://auth0.com/) as its authentication and authorization server. As they also provide extensive documentation, we link to their documentation in some places on this page.
 
+## Requirements
+
+-   A client id
+-   A client secret
+
+See [requesting client credentials](./requesting-credentials.md) how to obtain a set of client credentials. 
+
+Additionally, we will need to configure the following settings for your client on our end:
+
+*   Login URL: In some cases the authorization server will need to redirect the user back to a login URL on your application. This URL should point to a route in your application that ends up redirecting to the `/authorize` endpoint on publiq's authorization server, e.g. `https://example.com/login`. Note that it requires `https` and it cannot point to `localhost`. It can include query parameters and a URI fragment.
+*   Callback URL(s): The absolute URL(s) of the page(s) where your users can be redirected back to after they log in. You can specify any callback URL whenever you redirect a user to the authorization server to log in, but it needs to be registered on our end first to prevent phishing attacks. For example `https://example.com/authorize`.
+
+If you wish to use user access tokens, make sure to specify your login URL and callback URLs when requesting your client credentials.
+
+<!-- theme: warning -->
+
+> Without these login URL and callback URLs configured for your application **on our authorization server**, the login flow will not work for your client due to security reasons!
+
+> For more info about the login and callback URLs, see the Auth0 documentation about [application URIs](https://auth0.com/docs/get-started/dashboard/application-settings#application-uris). Note that other URIs mentioned in that documentation page are not required for most applications.
+
+## Flow
 
 ### Regular web applications
 
@@ -36,25 +57,6 @@ To learn more about the Authorization Code Flow with PKCE, see the [the Auth0 do
 > ##### SDK
 >
 > If you want, you can use the [Single-Page Application (SPA) SDK Libraries](https://auth0.com/docs/libraries#spa) provided by Auth0 to implement this flow in frontend Javascript applications. Native applications can use the [Native and Mobile Application SDK Libraries](https://auth0.com/docs/libraries#native).
-
-## Client configuration
-
-Before you can use one of the Authorization Code flows above, your client needs the following configuration **on the authorization server**:
-
-*   **Login URI**: The absolute URI of the page where your users will login. For example `https://example.com/login`.
-*   **Callback URL(s)**: The absolute URL(s) of the page(s) where your users can be redirected back to after they log in. You can specify this callback URL whenever you redirect a user to the authorization server to log in, but it needs to be **whitelisted** first to prevent phishing attacks. For example `https://example.com/authorize`.
-
-Additionally, if you want to use the PKCE flow you will also need to specify:
-
-*   **Allowed Origins (CORS)**: The domain name(s) of the application(s) that you will be using the PKCE flow on. For example `example.com`.
-
-> For more info, see the Auth0 documentation about [application URIs](https://auth0.com/docs/get-started/dashboard/application-settings#application-uris).
-
-<!-- theme: success -->
-
-> A way to configure your client's settings on the authorization server will be provided in the future.
->
-> In the meantime you can contact vragen@uitdatabank.be to make sure your client has the correct URI configuration on the authorization server or make changes.
 
 ## Domains
 


### PR DESCRIPTION
### Added

- List of requirements per authentication method

### Changed

- Changes in structure of the pages for the different authentication methods, to accomodate the requirements sections
- Reworded some small parts and/or removed outdated info (like that frontend apps should always use the `?clientId` url param instead of the `x-client-id` header, or that an "Allowed origin (CORS)" is required for PKCE flow)

---

Ticket: https://jira.uitdatabank.be/browse/API-54

Note: I will make some bigger improvements to the guides for the different authentication methods in other PRs, this one just focuses on documenting the requirements on each page.

Preview branch (then navigate to the specific guides per auth method): https://docs.publiq.be/docs/authentication/branches/authentication%2FAPI-54-requirements-per-method/d6a8ba3f3c186-introduction (login with apidocs@publiq.be required) 
