### PR TITLE
Update CODEOWNERS of authentication docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 * @bertramakers
 
 # Authentication owners
-/projects/authentication @bertramakers @erwin1
+/projects/authentication @bertramakers @corneelwille @JurgenG @JonasVHG
 
 # museumPASSmusées owners
 /projects/museumpassmusees @bertramakers @erwin1


### PR DESCRIPTION
### Added

- Added @corneelwille , @JonasVHG and @JurgenG as code owners of the authentication docs

### Removed

- Removed @erwin1 as code owner from the authentication docs to avoid too much noise from PRs not relevant for him. We will ping him if a specific PR requires his input