### PR TITLE
API-99 Fix empty OAuth2 URLs on docs.publiq.be

### DIFF
--- a/projects/museumpassmusees/reference/partner-api.json
+++ b/projects/museumpassmusees/reference/partner-api.json
@@ -189,7 +189,7 @@
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       }
     },
     "responses": {

--- a/projects/museumpassmusees/reference/partner-api.json
+++ b/projects/museumpassmusees/reference/partner-api.json
@@ -188,13 +188,7 @@
     "securitySchemes": {
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
-        "flows": {
-          "clientCredentials": {
-            "tokenUrl": "",
-            "refreshUrl": "",
-            "scopes": {}
-          }
-        },
+        "flows": {},
         "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       }
     },

--- a/projects/museumpassmusees/reference/partner-api.json
+++ b/projects/museumpassmusees/reference/partner-api.json
@@ -189,7 +189,7 @@
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://docs.publiq.be/docs/authentication/methods/client-access-token) for more info."
       }
     },
     "responses": {

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -5961,12 +5961,12 @@
       "USER_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
+        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login using the **Authorization Code OAuth Flow**. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       }
     },
     "parameters": {

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -5961,12 +5961,12 @@
       "USER_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login using the **Authorization Code OAuth Flow**. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
+        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login using the **Authorization Code OAuth Flow**. See the [authentication docs about user access tokens](https://docs.publiq.be/docs/authentication/methods/client-access-token) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://docs.publiq.be/docs/authentication/methods/user-access-token) for more info."
       }
     },
     "parameters": {

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -5960,25 +5960,12 @@
     "securitySchemes": {
       "USER_ACCESS_TOKEN": {
         "type": "oauth2",
-        "flows": {
-          "authorizationCode": {
-            "authorizationUrl": "",
-            "tokenUrl": "",
-            "refreshUrl": "",
-            "scopes": {}
-          }
-        },
+        "flows": {},
         "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
-        "flows": {
-          "clientCredentials": {
-            "tokenUrl": "",
-            "refreshUrl": "",
-            "scopes": {}
-          }
-        },
+        "flows": {},
         "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       }
     },

--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -5820,12 +5820,12 @@
       "USER_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login using the **Authorization Code OAuth Flow**. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
+        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login using the **Authorization Code OAuth Flow**. See the [authentication docs about user access tokens](https://docs.publiq.be/docs/authentication/methods/user-access-token) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://docs.publiq.be/docs/authentication/methods/client-access-token) for more info."
       },
       "CLIENT_IDENTIFICATION": {
         "name": "x-client-id",

--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -5819,25 +5819,12 @@
     "securitySchemes": {
       "USER_ACCESS_TOKEN": {
         "type": "oauth2",
-        "flows": {
-          "authorizationCode": {
-            "authorizationUrl": "",
-            "tokenUrl": "",
-            "refreshUrl": "",
-            "scopes": {}
-          }
-        },
+        "flows": {},
         "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
-        "flows": {
-          "clientCredentials": {
-            "tokenUrl": "",
-            "refreshUrl": "",
-            "scopes": {}
-          }
-        },
+        "flows": {},
         "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       },
       "CLIENT_IDENTIFICATION": {

--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -5820,12 +5820,12 @@
       "USER_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
+        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login using the **Authorization Code OAuth Flow**. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
         "flows": {},
-        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server using the **Client Credentials OAuth Flow**. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       },
       "CLIENT_IDENTIFICATION": {
         "name": "x-client-id",


### PR DESCRIPTION
### Removed

- Removed all `flows` from the `securitySchemes` in all OpenAPI files. This way the (empty) URLs are not shown, and Spectral does not complain about the OpenAPI file being invalid like it would if we kept the `clientCredentials` or `authorizationCode` flows without `authorizationUrl`, `tokenUrl`, `refreshUrl`, or `scopes`

### Added

- Mentioned the specific OAuth2 grant type (flow) in the `securitySchemes` description, so it's still clear for humans reading these docs what specific flow is used for each securityScheme using the standardized names from OAuth2.

---

Ticket: https://jira.uitdatabank.be/browse/API-99

Note: We cannot enter a concrete URL because they are different for test and production, and we can only enter one. Plus with just the URL and the grant type you cannot do the auth flow, you also need to know the required `audience`, which can only be found in the auth docs because OpenAPI has no parameter for it.
