### PR TITLE
API-104 Fix workflows not being triggered after running the docs fixer

### DIFF
--- a/.github/workflows/linting-docs-fix.yml
+++ b/.github/workflows/linting-docs-fix.yml
@@ -6,6 +6,14 @@ jobs:
     steps:
       -   name: Checkout
           uses: actions/checkout@v2
+          with: 
+            # We need to use a PAT for the dev@publiq.be user to commit the changes in that user's name. Otherwise it would be committed
+            # by a "Github Actions" user, which would not trigger a new workflow run, preventing the CI checks from running after this
+            # fixer job has run.
+            # If the PAT ever expires or stops working, log in as dev@publiq.be on Github (see Bitwarden) and then generate a new PAT
+            # at https://github.com/settings/tokens
+            # For more info, see https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+            token: ${{ secrets.PAT_DEV_AT_PUBLIQ }}
       -   name: Lint & fix Markdown docs
           run: yarn && yarn docs:lint:fix
       -   name: Push changes back to repository

--- a/projects/uitdatabank/docs/entry-api/requirements-before-going-live.md
+++ b/projects/uitdatabank/docs/entry-api/requirements-before-going-live.md
@@ -48,6 +48,7 @@ It is important that you go through the checklist below in advance and validate 
 * `bookingInfo`: add a ticketing link or contact details for reservation if applicable
 
 <!-- theme: warning -->
+
 > Albeit optional, note that these properties are often necessary in order for it to be published in an online calendar. This is especially the case for the `description`, `typicalAgeRange` and the `mediaObject`.
 
 When the created content & integration meets the listed conditions, we will immediately give you access to our production environment (see step 3). If necessary, we ask you to make some adjustments to the made integration.


### PR DESCRIPTION
### Fixed

- Fixed the CI checks not being triggered automatically after running the job to fix linting issues in the docs

---

Ticket: https://jira.uitdatabank.be/browse/API-104
