### PR TITLE
Remove Stan as owner of museumPASSmusées API docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /projects/museumpassmusees @bertramakers @erwin1
 
 # museumPASSmusées Markdown docs owners
-/projects/museumpassmusees/docs @bertramakers @erwin1 @Stiksels @DizzyMissLizzy
+/projects/museumpassmusees/docs @bertramakers @erwin1 @DizzyMissLizzy
 
 # UiTdatabank owners
 /projects/uitdatabank @bertramakers @LucWollants


### PR DESCRIPTION
### Removed

- Removed @Stiksels as owner of the museumPASSmusées API docs now that @DizzyMissLizzy has token over as project manager of museumPASSmusées
