### PR TITLE
Fix `main` not being deployed to `unreleased`

### DIFF
--- a/.github/actions/stoplight-push/action.yml
+++ b/.github/actions/stoplight-push/action.yml
@@ -44,6 +44,6 @@ runs:
       run: echo "${{ env.project_files_changed_count }}"
 
     - name: Publish
-      if: ${{ env.project_files_changed_count > 0 || inputs.event == 'workflow_dispatch' }}
+      if: ${{ env.project_files_changed_count > 0 || inputs.event == 'workflow_dispatch' || env.branch_name == 'main' || env.branch_name == 'unreleased' }}
       shell: bash
       run: npx @stoplight/cli@5 push -d projects/${{ inputs.name }} -b ${{ env.branch_name }} --ci-token ${{ inputs.token }} --verbose


### PR DESCRIPTION
### Fixed

- Fixed `main` not being deployed to `unreleased` because it will always have 0 changed files compared to `main`
