### PR TITLE
Replace "geo distance" with "coordinates" and "distance"

### DIFF
--- a/projects/uitdatabank/docs/search-api/sorting.md
+++ b/projects/uitdatabank/docs/search-api/sorting.md
@@ -49,7 +49,7 @@ Newly created organizers will appear first.
 
 > Only applicable on `/events`, `/places` and `/offers`, and only when the the `coordinates` and `distance` parameters are also present
 
-When searching by `geo distance`, it is possible to sort the results by the distance from the given coordinates.
+When searching by `coordinates` and `distance`, it is possible to sort the results by the distance from the given coordinates.
 
 **Example**
 


### PR DESCRIPTION
### Changed

- Replaced "geo distance" with "coordinates" and "distance". The "geo distance" was copied from the old docs and put between backticks instead of the link that it was to a guide to searching by coordinates & distance (which does not exist in the new docs right now). But backticks indicate that it's a technical property/parameter/option/... while it does not exist.

---

I just happened to notice this while linking to this for someone who had a question about searching by distance
