### PR TITLE
UiTdatabank III-4272: JSON schema for endpoint to update `workflowStatus`

### DIFF
--- a/projects/uitdatabank/models/common-workflowStatus-offer.json
+++ b/projects/uitdatabank/models/common-workflowStatus-offer.json
@@ -1,11 +1,12 @@
 {
   "title": "workflowStatus",
   "type": "string",
-  "description": "The status in the moderation workflow.\n\nCan be one of four types:\n\n- `DRAFT`: Should not be visible on publication channels yet\n- `READY_FOR_VALIDATION`: Submitted for validation. Some publication channels may choose to show these.\n- `APPROVED`: Approved, will be visible on all publication channels (depending on the `availableFrom` and `availableTo`)\n- `DELETED`: Removed and should not be visible on any publication channels.",
+  "description": "The status in the moderation workflow.\n\nCan be one of four types:\n\n- `DRAFT`: Should not be visible on publication channels yet\n- `READY_FOR_VALIDATION`: Submitted for validation. Some publication channels may choose to show these.\n- `APPROVED`: Approved, will be visible on all publication channels (depending on the `availableFrom` and `availableTo`). Only possible if you have moderation permissions.\n- `REJECTED`: Rejected, will be hidden from all publication channels. Only possible if you have moderation permissions.\n- `DELETED`: Removed and should not be visible on any publication channels.",
   "enum": [
     "DRAFT",
     "READY_FOR_VALIDATION",
     "APPROVED",
+    "REJECTED",
     "DELETED"
   ],
   "examples": [

--- a/projects/uitdatabank/models/event-workflowStatus-put.json
+++ b/projects/uitdatabank/models/event-workflowStatus-put.json
@@ -1,0 +1,12 @@
+{
+  "title": "event.workflowStatus.put",
+  "type": "object",
+  "properties": {
+    "workflowStatus": {
+      "$ref": "./event-workflowStatus.json"
+    }
+  },
+  "required": [
+    "workflowStatus"
+  ]
+}

--- a/projects/uitdatabank/models/event-workflowStatus-put.json
+++ b/projects/uitdatabank/models/event-workflowStatus-put.json
@@ -8,9 +8,23 @@
     "availableFrom": {
       "$ref": "./event-availableFrom.json",
       "description": "The first date & time that the [event](./event.json) is allowed to be visible on publication channels. Can be set when changing the workflowStatus to READY_FOR_VALIDATION. If omitted when changing the workflowStatus to READY_FOR_VALIDATION, the current datetime will be used. Must be formatted as an ISO-8601 datetime, for example `2021-05-17T22:00:00+00:00`."
+    },
+    "reason": {
+      "type": "string",
+      "description": "Required when setting the workflowStatus to `REJECTED` (only possible with permission to moderate events). The reason why the event was rejected."
     }
   },
   "required": [
     "workflowStatus"
-  ]
+  ],
+  "if": {
+    "properties": {
+      "workflowStatus": {
+        "const": "REJECTED"
+      }
+    }
+  },
+  "then": {
+    "required": ["reason"]
+  }
 }

--- a/projects/uitdatabank/models/event-workflowStatus-put.json
+++ b/projects/uitdatabank/models/event-workflowStatus-put.json
@@ -4,6 +4,10 @@
   "properties": {
     "workflowStatus": {
       "$ref": "./event-workflowStatus.json"
+    },
+    "availableFrom": {
+      "$ref": "./event-availableFrom.json",
+      "description": "The first date & time that the [event](./event.json) is allowed to be visible on publication channels. Can be set when changing the workflowStatus to READY_FOR_VALIDATION. If ommitted when changing the workflowStatus to READY_FOR_VALIDATION, the current datetime will be used. Must be formatted as an ISO-8601 datetime, for example `2021-05-17T22:00:00+00:00`."
     }
   },
   "required": [

--- a/projects/uitdatabank/models/event-workflowStatus-put.json
+++ b/projects/uitdatabank/models/event-workflowStatus-put.json
@@ -7,7 +7,7 @@
     },
     "availableFrom": {
       "$ref": "./event-availableFrom.json",
-      "description": "The first date & time that the [event](./event.json) is allowed to be visible on publication channels. Can be set when changing the workflowStatus to READY_FOR_VALIDATION. If ommitted when changing the workflowStatus to READY_FOR_VALIDATION, the current datetime will be used. Must be formatted as an ISO-8601 datetime, for example `2021-05-17T22:00:00+00:00`."
+      "description": "The first date & time that the [event](./event.json) is allowed to be visible on publication channels. Can be set when changing the workflowStatus to READY_FOR_VALIDATION. If omitted when changing the workflowStatus to READY_FOR_VALIDATION, the current datetime will be used. Must be formatted as an ISO-8601 datetime, for example `2021-05-17T22:00:00+00:00`."
     }
   },
   "required": [

--- a/projects/uitdatabank/models/place-workflowStatus-put.json
+++ b/projects/uitdatabank/models/place-workflowStatus-put.json
@@ -7,7 +7,7 @@
     },
     "availableFrom": {
       "$ref": "./place-availableFrom.json",
-      "description": "The first date & time that the [place](./place.json) is allowed to be visible on publication channels. Can be set when changing the workflowStatus to READY_FOR_VALIDATION. If ommitted when changing the workflowStatus to READY_FOR_VALIDATION, the current datetime will be used. Must be formatted as an ISO-8601 datetime, for example `2021-05-17T22:00:00+00:00`."
+      "description": "The first date & time that the [place](./place.json) is allowed to be visible on publication channels. Can be set when changing the workflowStatus to READY_FOR_VALIDATION. If omitted when changing the workflowStatus to READY_FOR_VALIDATION, the current datetime will be used. Must be formatted as an ISO-8601 datetime, for example `2021-05-17T22:00:00+00:00`."
     }
   },
   "required": [

--- a/projects/uitdatabank/models/place-workflowStatus-put.json
+++ b/projects/uitdatabank/models/place-workflowStatus-put.json
@@ -8,9 +8,23 @@
     "availableFrom": {
       "$ref": "./place-availableFrom.json",
       "description": "The first date & time that the [place](./place.json) is allowed to be visible on publication channels. Can be set when changing the workflowStatus to READY_FOR_VALIDATION. If omitted when changing the workflowStatus to READY_FOR_VALIDATION, the current datetime will be used. Must be formatted as an ISO-8601 datetime, for example `2021-05-17T22:00:00+00:00`."
+    },
+    "reason": {
+      "type": "string",
+      "description": "Required when setting the workflowStatus to `REJECTED` (only possible with permission to moderate events). The reason why the event was rejected."
     }
   },
   "required": [
     "workflowStatus"
-  ]
+  ],
+  "if": {
+    "properties": {
+      "workflowStatus": {
+        "const": "REJECTED"
+      }
+    }
+  },
+  "then": {
+    "required": ["reason"]
+  }
 }

--- a/projects/uitdatabank/models/place-workflowStatus-put.json
+++ b/projects/uitdatabank/models/place-workflowStatus-put.json
@@ -1,0 +1,16 @@
+{
+  "title": "place.workflowStatus.put",
+  "type": "object",
+  "properties": {
+    "workflowStatus": {
+      "$ref": "./place-workflowStatus.json"
+    },
+    "availableFrom": {
+      "$ref": "./place-availableFrom.json",
+      "description": "The first date & time that the [place](./place.json) is allowed to be visible on publication channels. Can be set when changing the workflowStatus to READY_FOR_VALIDATION. If ommitted when changing the workflowStatus to READY_FOR_VALIDATION, the current datetime will be used. Must be formatted as an ISO-8601 datetime, for example `2021-05-17T22:00:00+00:00`."
+    }
+  },
+  "required": [
+    "workflowStatus"
+  ]
+}


### PR DESCRIPTION
### Added

- Added a JSON schema for a new endpoint to update an event's/place's workflowStatus (as an alternative to the PATCH endpoint that uses custom content-types to determine the intended state transition, which is quirky). The endpoint itself will be documented later in https://jira.uitdatabank.be/browse/III-5106

---

Ticket: https://jira.uitdatabank.be/browse/III-4272
