### PR TITLE
UiTdatabank: Document missing SAPI3 locationLabels and organizerLabels URL parameters

### DIFF
--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -1363,6 +1363,32 @@
         "description": "Returns only results that have the given label(s) in either their `labels` or `hiddenLabels` properties. May be repeated to only return results that have all the given labels. See the operation's description above for more info on how to repeat parameters.",
         "explode": true
       },
+      "locationLabels": {
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "in": "query",
+        "name": "locationLabels[]",
+        "style": "form",
+        "description": "Returns only results that have the given label(s) in their location's `labels` or `hiddenLabels` properties. May be repeated to only return results with a location that has all the given labels. See the operation's description above for more info on how to repeat parameters.",
+        "explode": true
+      },
+      "organizerLabels": {
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "in": "query",
+        "name": "organizerLabels[]",
+        "style": "form",
+        "description": "Returns only results that have the given label(s) in their organizer's `labels` or `hiddenLabels` properties. May be repeated to only return results with an organizer that has all the given labels. See the operation's description above for more info on how to repeat parameters.",
+        "explode": true
+      },
       "mainLanguage": {
         "schema": {
           "type": "string",

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -897,6 +897,9 @@
             "$ref": "#/components/parameters/labels"
           },
           {
+            "$ref": "#/components/parameters/organizerLabels"
+          },
+          {
             "$ref": "#/components/parameters/mainLanguage"
           },
           {

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -488,6 +488,12 @@
             "$ref": "#/components/parameters/labels"
           },
           {
+            "$ref": "#/components/parameters/locationLabels"
+          },
+          {
+            "$ref": "#/components/parameters/organizerLabels"
+          },
+          {
             "$ref": "#/components/parameters/mainLanguage"
           },
           {

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -221,6 +221,12 @@
             "$ref": "#/components/parameters/labels"
           },
           {
+            "$ref": "#/components/parameters/locationLabels"
+          },
+          {
+            "$ref": "#/components/parameters/organizerLabels"
+          },
+          {
             "$ref": "#/components/parameters/mainLanguage"
           },
           {


### PR DESCRIPTION
### Added

- Added missing `locationLabels` URL parameter to `GET /events` and `GET /offers`
- Added missing `organizerLabels` URL parameter to `GET /events`, `GET /places` and `GET /offers`
