### PR TITLE
UiTdatabank: Remove Taxonomy API test URL

### DIFF
--- a/projects/uitdatabank/reference/taxonomy.json
+++ b/projects/uitdatabank/reference/taxonomy.json
@@ -12,10 +12,6 @@
   },
   "servers": [
     {
-      "url": "https://taxonomy-test.uitdatabank.be",
-      "description": "Testing"
-    },
-    {
       "description": "Production",
       "url": "https://taxonomy.uitdatabank.be"
     }


### PR DESCRIPTION
### Removed

- Removed Taxonomy API test URL. This is only used for internal purposes (to test deployments before pushing them to the production URL). And the documentation already mentions "The taxonomy API only has one environment, the production environment. Since the taxonomy terms are the same on all environments, you can also connect to this environment from your testing environment to retrieve taxonomy terms." So having a test URL in the OpenAPI documentation is confusing in that case.
