### PR TITLE
Update checkout action to v3

### DIFF
--- a/.github/actions/stoplight-push/action.yml
+++ b/.github/actions/stoplight-push/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Replace image URLs in .md files
       shell: bash
-      run: cd projects/${{ inputs.name }}/docs && find . -type f -name '*.md' -exec sed -i -r 's_\]\([./]+/assets/_](https://raw.githubusercontent.com/cultuurnet/apidocs/${{ env.branch_name }}/projects/${{ inputs.name }}/assets/_g' {} +
+      run: cd projects/${{ inputs.name }}/docs && find . -type f -name '*.md' -exec sed -i -r 's;\]\([./]+/assets/;](https://raw.githubusercontent.com/cultuurnet/apidocs/${{ env.branch_name }}/projects/${{ inputs.name }}/assets/;g' {} +
 
     - name: Rename branch from 'main' to 'unreleased'
       if: ${{ env.branch_name == 'main' && inputs.event != 'workflow_dispatch' }}

--- a/.github/workflows/linting-docs-fix.yml
+++ b/.github/workflows/linting-docs-fix.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -   name: Checkout
-          uses: actions/checkout@v2
-          with: 
+          uses: actions/checkout@v3
+          with:
             # We need to use a PAT for the dev@publiq.be user to commit the changes in that user's name. Otherwise it would be committed
             # by a "Github Actions" user, which would not trigger a new workflow run, preventing the CI checks from running after this
             # fixer job has run.

--- a/.github/workflows/linting-docs.yml
+++ b/.github/workflows/linting-docs.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -   name: Checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
       -   name: Lint Markdown docs
           run: yarn && yarn docs:lint

--- a/.github/workflows/linting-openapi.yml
+++ b/.github/workflows/linting-openapi.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Lint OpenAPI file(s)
         run: yarn && yarn api:lint

--- a/.github/workflows/split-udb3-json-schemas.yml
+++ b/.github/workflows/split-udb3-json-schemas.yml
@@ -12,7 +12,7 @@ jobs:
     name: Update cultuurnet/udb3-json-schemas repo
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Split

--- a/projects/uitdatabank/docs/search-api/embedding.md
+++ b/projects/uitdatabank/docs/search-api/embedding.md
@@ -201,7 +201,7 @@ Every result in the response will have a `calendarSummary` property with a value
 }
 ```
 
-#### Calendar summary `sm-text` for an event that is happening tonight 
+#### Calendar summary `sm-text` for an event that is happening tonight
 
 ```json
 {
@@ -227,7 +227,6 @@ Every result in the response will have a `calendarSummary` property with a value
    }
 }
 ```
-
 
 #### Calendar summary `md-text` for a cancelled event
 
@@ -265,7 +264,6 @@ Every result in the response will have a `calendarSummary` property with a value
    }
 }
 ```
-
 
 #### Calendar summary `lg-html` for an event that is sold out or fully booked
 


### PR DESCRIPTION
### Changed

- Update checkout action to v3 to get rid of GitHub deprecation warnings for NodeJS 12.