### PR TITLE
Clarify autocomplete behaviour in SAPI3 organizers `name` parameter

### DIFF
--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -1014,7 +1014,7 @@
         },
         "in": "query",
         "name": "name",
-        "description": "Returns only results whose name autocompletes on the given name."
+        "description": "Returns only results whose name autocompletes on the given name. For example searching for `pub` will return matches with `publiq` in the name."
       },
       "website": {
         "schema": {


### PR DESCRIPTION
### Changed

- Added an example to clarify the autocomplete behaviour in SAPI3 organizers `name` parameter

