### PR TITLE
UiTdatabank: "Advanced queries" guide tweaks

### DIFF
--- a/projects/uitdatabank/docs/search-api/advanced-queries.md
+++ b/projects/uitdatabank/docs/search-api/advanced-queries.md
@@ -4,7 +4,7 @@ Every endpoint on Search API supports various URL parameters for the most common
 
 With advanced queries you can make more complex queries using boolean operators, keywords and/or specific field values, and grouping.
 
-The syntax is the Lucene query syntax. More details about the syntax can be found in the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax) and [Apache Lucene documentation](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters).
+Advanced queries are defined using the `q` parameter which uses the Lucene query syntax. More details about the syntax can be found in the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax) and [Apache Lucene documentation](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters).
 
 ## Supported fields
 

--- a/projects/uitdatabank/docs/search-api/advanced-queries.md
+++ b/projects/uitdatabank/docs/search-api/advanced-queries.md
@@ -1,8 +1,10 @@
 # Advanced queries
 
-With advanced queries you can make more complex queries, using boolean operators, search keywords and/or specific field values, and grouping.
+Every endpoint on Search API supports various URL parameters for the most common filters. However these URL parameters have certain limitations, for example grouping and custom boolean operators are not possible.
 
-The syntax is based on the Lucene query syntax. More info about the syntax can be found in the [ElasticSearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax).
+With advanced queries you can make more complex queries using boolean operators, keywords and/or specific field values, and grouping.
+
+The syntax is the Lucene query syntax. More details about the syntax can be found in the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax) and [Apache Lucene documentation](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters).
 
 ## Supported fields
 

--- a/projects/uitdatabank/docs/search-api/advanced-queries.md
+++ b/projects/uitdatabank/docs/search-api/advanced-queries.md
@@ -1103,7 +1103,7 @@ The `+` sign should be encoded for as `%2B`. Otherwise it will be interpreted as
 GET /events/?q=dateRange:[2022-01-01T00:00:00%2B01:00%20TO%202022-12-31T23:59:59%2B01:00]
 ```
 
-## Resources
+## Other resources
 
 * [Elasticsearch Lucene Query Syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax)
 * [List of special characters that require escaping](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters)

--- a/projects/uitdatabank/docs/search-api/advanced-queries.md
+++ b/projects/uitdatabank/docs/search-api/advanced-queries.md
@@ -1105,5 +1105,5 @@ GET /events/?q=dateRange:[2022-01-01T00:00:00%2B01:00%20TO%202022-12-31T23:59:59
 
 ## Resources
 
-* [Elastic Search Lucene Query Syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax)
+* [Elasticsearch Lucene Query Syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax)
 * [List of special characters that require escaping](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters)

--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -87,12 +87,6 @@
       "items": [
         {
           "type": "item",
-          "title": "Advanced queries",
-          "uri": "/docs/search-api/advanced-queries.md",
-          "slug": "search-api/advanced-queries"
-        },
-        {
-          "type": "item",
           "title": "Default filters",
           "uri": "/docs/search-api/default-filters.md",
           "slug": "search-api/default-filters"
@@ -114,6 +108,12 @@
           "title": "Sorting",
           "uri": "/docs/search-api/sorting.md",
           "slug": "search-api/sorting"
+        },
+        {
+          "type": "item",
+          "title": "Advanced queries",
+          "uri": "/docs/search-api/advanced-queries.md",
+          "slug": "search-api/advanced-queries"
         },
         {
           "type": "item",

--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -86,40 +86,52 @@
       "title": "Guides",
       "items": [
         {
-          "type": "item",
-          "title": "Default filters",
-          "uri": "/docs/search-api/default-filters.md",
-          "slug": "search-api/default-filters"
+          "type": "group",
+          "title": "Getting started",
+          "items": [
+            {
+              "type": "item",
+              "title": "Default filters",
+              "uri": "/docs/search-api/default-filters.md",
+              "slug": "search-api/default-filters"
+            },
+            {
+              "type": "item",
+              "title": "Embedding",
+              "uri": "/docs/search-api/embedding.md",
+              "slug": "search-api/embedding"
+            },
+            {
+              "type": "item",
+              "title": "Pagination",
+              "uri": "/docs/search-api/pagination.md",
+              "slug": "search-api/pagination"
+            },
+            {
+              "type": "item",
+              "title": "Sorting",
+              "uri": "/docs/search-api/sorting.md",
+              "slug": "search-api/sorting"
+            }
+          ]
         },
         {
-          "type": "item",
-          "title": "Embedding",
-          "uri": "/docs/search-api/embedding.md",
-          "slug": "search-api/embedding"
-        },
-        {
-          "type": "item",
-          "title": "Pagination",
-          "uri": "/docs/search-api/pagination.md",
-          "slug": "search-api/pagination"
-        },
-        {
-          "type": "item",
-          "title": "Sorting",
-          "uri": "/docs/search-api/sorting.md",
-          "slug": "search-api/sorting"
-        },
-        {
-          "type": "item",
-          "title": "Advanced queries",
-          "uri": "/docs/search-api/advanced-queries.md",
-          "slug": "search-api/advanced-queries"
-        },
-        {
-          "type": "item",
-          "title": "Facets",
-          "uri": "/docs/search-api/facets.md",
-          "slug": "search-api/facets"
+          "type": "group",
+          "title": "Advanced features",
+          "items": [
+            {
+              "type": "item",
+              "title": "Advanced queries",
+              "uri": "/docs/search-api/advanced-queries.md",
+              "slug": "search-api/advanced-queries"
+            },
+            {
+              "type": "item",
+              "title": "Facets",
+              "uri": "/docs/search-api/facets.md",
+              "slug": "search-api/facets"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
### Changed

- Added a little bit more context in the "Advanced queries" guide
- Changed the order of SAPI3 guides and split them up in "Getting started" and "Advanced features", so we can add something like "Common search scenario's" in a later PR with guides like "Searching by location", "Searching by date(s)", etc.
- Minor fixes / tweaks
