### PR TITLE
Rename "School events" guide to use verb in sidebar

### DIFF
--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -34,7 +34,7 @@
           "items": [
             {
               "type": "item",
-              "title": "School events",
+              "title": "Creating school events",
               "uri": "/docs/entry-api/events/school-events.md",
               "slug": "entry-api/events/school-events"
             }


### PR DESCRIPTION
### Changed

- Start the "School events" link in the sidebar with a verb to explain the use case
