### PR TITLE
Uitdatabank - fix offer empty description put

### DIFF
--- a/projects/uitdatabank/models/event-description-put.json
+++ b/projects/uitdatabank/models/event-description-put.json
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "description": {
-      "$ref": "./common-description-localized.json",
+      "type": "string",
       "description": "A human-readable description of the [event](./event.json) localized in the language from the URL parameter."
     }
   },

--- a/projects/uitdatabank/models/place-description-put.json
+++ b/projects/uitdatabank/models/place-description-put.json
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "description": {
-      "$ref": "./common-description-localized.json",
+      "type": "string",
       "description": "A human-readable description of the [place](./place.json) localized in the language from the URL parameter."
     }
   },


### PR DESCRIPTION
### Fixed
- Allow the description to be an empty string when updating an offer.

---

Ticket: https://jira.uitdatabank.be/browse/III-4251
