### PR TITLE
Uitdatabank - images post

### DIFF
--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -3274,14 +3274,14 @@
     },
     "/images": {
       "post": {
-        "summary": "image - create",
+        "summary": "image - upload",
         "operationId": "image-post",
         "tags": [
           "Images"
         ],
-        "description": "Creates an image, which you can later link to one or more events, places, and organizers. Only images up to 21 million bytes (~ 20 MB) are allowed. The expected image format is `.png`, `.jpeg` or `.gif`.",
+        "description": "Uploads an image, which you can later link to one or more events, places, and organizers. Only images up to 21 million bytes (~ 20 MB) are allowed. The expected image format is `.png`, `.jpeg` or `.gif`.",
         "requestBody": {
-          "description": "The image and the metadata to create.",
+          "description": "The image to upload and its metadata to store with it.",
           "content": {
             "multipart/form-data": {
               "schema": {

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -3279,7 +3279,7 @@
         "tags": [
           "Images"
         ],
-        "description": "Add images, which you can later link to one or more offers. Only images up to 21 million bytes (~ 20 MB) are allowed. The expected image format is `.png`, `.jpeg` or `.gif`.",
+        "description": "Creates an image, which you can later link to one or more events, places, and organizers. Only images up to 21 million bytes (~ 20 MB) are allowed. The expected image format is `.png`, `.jpeg` or `.gif`.",
         "requestBody": {
           "description": "The image and the metadata to create.",
           "content": {

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -3281,22 +3281,27 @@
         ],
         "description": "Add images, which you can later link to one or more offers. Only images up to 21 million bytes (~ 20 MB) are allowed. The expected image format is `.png`, `.jpeg` or `.gif`.",
         "requestBody": {
+          "description": "The image and the metadata to create.",
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "file": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The image to add."
                   },
                   "description": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "A description of the image."
                   },
                   "copyrightHolder": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The copyrightHolder of the image."
                   },
-                  "langauge": {
-                    "type": "string"
+                  "language": {
+                    "type": "string",
+                    "description": "The language of the description. It must be exactly 2 lowercase letters long (for example \"nl\")."
                   }
                 }
               },
@@ -3323,7 +3328,7 @@
                   "properties": {
                     "@id": {
                       "type": "string",
-                      "description": "The url of the created image",
+                      "description": "The url of the created image.",
                       "example": "https://io-test.uitdatabank.be/images/c71b9b61-73a9-435e-bb50-aadb05750d2d"
                     },
                     "imageId": {
@@ -3335,7 +3340,7 @@
                   },
                   "required": [
                     "@id",
-                    "@imageId"
+                    "imageId"
                   ]
                 },
                 "examples": {
@@ -3350,7 +3355,7 @@
             }
           },
           "400": {
-            "description": "Bad Request. Possible error types:\n\n* https://api.publiq.be/probs/body/file-missing\n* https://api.publiq.be/probs/body/file-invalid-type\n* https://api.publiq.be/probs/body/invalid-data",
+            "description": "Bad Request. Possible error types:\n\n* https://api.publiq.be/probs/body/file-missing\n* https://api.publiq.be/probs/body/file-invalid-type\n* https://api.publiq.be/probs/body/invalid-data\n* https://api.publiq.be/probs/body/missing\n* https://api.publiq.be/probs/body/invalid-syntax",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -7733,6 +7738,9 @@
       "name": "Events"
     },
     {
+      "name": "Images"
+    },
+    {
       "name": "News articles"
     },
     {
@@ -7740,9 +7748,6 @@
     },
     {
       "name": "Places"
-    },
-    {
-      "name": "Images"
     }
   ]
 }

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -3272,6 +3272,110 @@
         }
       }
     },
+    "/images": {
+      "post": {
+        "summary": "image - create",
+        "operationId": "image-post",
+        "tags": [
+          "Images"
+        ],
+        "description": "Add images, which you can later link to one or more offers. Only images up to 21 million bytes (~ 20 MB) are allowed. The expected image format is `.png`, `.jpeg` or `.gif`.",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "copyrightHolder": {
+                    "type": "string"
+                  },
+                  "langauge": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "Example": {
+                  "value": {
+                    "file": "@\"Screenshot 2017-11-28 12.37.19.png\"",
+                    "description": "Example description",
+                    "copyrightHolder": "Example copyrightHolder",
+                    "language": "nl"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The image was created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "@id": {
+                      "type": "string",
+                      "description": "The url of the created image",
+                      "example": "https://io-test.uitdatabank.be/images/c71b9b61-73a9-435e-bb50-aadb05750d2d"
+                    },
+                    "imageId": {
+                      "type": "string",
+                      "description": "The id of the created image.",
+                      "example": "c71b9b61-73a9-435e-bb50-aadb05750d2d",
+                      "format": "uuid"
+                    }
+                  },
+                  "required": [
+                    "@id",
+                    "@imageId"
+                  ]
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "@id": "https://io-test.uitdatabank.be/images/c71b9b61-73a9-435e-bb50-aadb05750d2d",
+                      "imageId": "c71b9b61-73a9-435e-bb50-aadb05750d2d"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Possible error types:\n\n* https://api.publiq.be/probs/body/file-missing\n* https://api.publiq.be/probs/body/file-invalid-type\n* https://api.publiq.be/probs/body/invalid-data",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "security": [
+          {
+            "USER_ACCESS_TOKEN": []
+          },
+          {
+            "CLIENT_ACCESS_TOKEN": []
+          }
+        ]
+      }
+    },
     "/places": {
       "post": {
         "summary": "place - create",
@@ -7636,6 +7740,9 @@
     },
     {
       "name": "Places"
+    },
+    {
+      "name": "Images"
     }
   ]
 }

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -3289,7 +3289,8 @@
                 "properties": {
                   "file": {
                     "type": "string",
-                    "description": "The image to add."
+                    "format": "binary",
+                    "description": "The image to upload."
                   },
                   "description": {
                     "type": "string",

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -3304,7 +3304,13 @@
                     "type": "string",
                     "description": "The language of the description. It must be exactly 2 lowercase letters long (for example \"nl\")."
                   }
-                }
+                },
+                "required": [
+                  "file",
+                  "description",
+                  "copyrightHolder",
+                  "language"
+                ]
               },
               "examples": {
                 "Example": {


### PR DESCRIPTION
You can double check the documentation [here](https://docs.publiq.be/docs/uitdatabank/branches/uitdatabank%2FIII-5100-post-images/1d9b45cbc812b-image-create)

### Added
- Documentation for POST `/images`

---

Ticket: https://jira.uitdatabank.be/browse/III-5100
