### PR TITLE
III-5162 Document location on attendanceMode update endpoint

### DIFF
--- a/projects/uitdatabank/models/event-@id.json
+++ b/projects/uitdatabank/models/event-@id.json
@@ -4,7 +4,6 @@
   "format": "uri",
   "pattern": "^http[s]?:\\/\\/.+?\\/event[s]?\\/([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12})[\\/]?",
   "description": "A unique URI that acts as globally unique ID for the [event](./event.json). Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers",
-  "readOnly": true,
   "examples": [
     "https://io-test.uitdatabank.be/event/85b04295-479c-40f5-b3dd-469dfb4387b3"
   ]

--- a/projects/uitdatabank/models/event-attendanceMode-put.json
+++ b/projects/uitdatabank/models/event-attendanceMode-put.json
@@ -15,5 +15,20 @@
   "additionalProperties": false,
   "required": [
     "attendanceMode"
-  ]
+  ],
+  "if": {
+    "properties": {
+      "attendanceMode": {
+        "const": "online"
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "attendanceMode": {
+        "$ref": "./event-attendanceMode.json"
+      }
+    },
+    "additionalProperties": false
+  }
 }

--- a/projects/uitdatabank/models/event-attendanceMode-put.json
+++ b/projects/uitdatabank/models/event-attendanceMode-put.json
@@ -13,20 +13,5 @@
   "additionalProperties": false,
   "required": [
     "attendanceMode"
-  ],
-  "if": {
-    "properties": {
-      "attendanceMode": {
-        "const": "online"
-      }
-    }
-  },
-  "then": {
-    "properties": {
-      "attendanceMode": {
-        "$ref": "./event-attendanceMode.json"
-      }
-    },
-    "additionalProperties": false
-  }
+  ]
 }

--- a/projects/uitdatabank/models/event-attendanceMode-put.json
+++ b/projects/uitdatabank/models/event-attendanceMode-put.json
@@ -6,8 +6,10 @@
       "$ref": "./event-attendanceMode.json"
     },
     "location": {
-      "$ref": "./place-@id.json",
-      "readOnly": false
+      "type": "string",
+      "format": "uri",
+      "pattern": "^http[s]?:\\/\\/.+?\\/place[s]?\\/([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12})[\\/]?",
+      "description": "A unique URI that acts as globally unique ID for the [place](./place.json). Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers"
     }
   },
   "additionalProperties": false,

--- a/projects/uitdatabank/models/event-attendanceMode-put.json
+++ b/projects/uitdatabank/models/event-attendanceMode-put.json
@@ -6,10 +6,7 @@
       "$ref": "./event-attendanceMode.json"
     },
     "location": {
-      "type": "string",
-      "format": "uri",
-      "pattern": "^http[s]?:\\/\\/.+?\\/place[s]?\\/([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12})[\\/]?",
-      "description": "A unique URI that acts as globally unique ID for the [place](./place.json). Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers"
+      "$ref": "./place-@id.json"
     }
   },
   "additionalProperties": false,

--- a/projects/uitdatabank/models/event-attendanceMode-put.json
+++ b/projects/uitdatabank/models/event-attendanceMode-put.json
@@ -6,7 +6,8 @@
       "$ref": "./event-attendanceMode.json"
     },
     "location": {
-      "$ref": "./place-@id.json"
+      "$ref": "./place-@id.json",
+      "readOnly": false
     }
   },
   "additionalProperties": false,

--- a/projects/uitdatabank/models/organizer-@id.json
+++ b/projects/uitdatabank/models/organizer-@id.json
@@ -6,6 +6,5 @@
   "examples": [
     "https://io-test.uitdatabank.be/organizers/5cf42d51-3a4f-46f0-a8af-1cf672be8c84"
   ],
-  "pattern": "^http[s]?:\\/\\/.+?\\/organizer[s]?\\/([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12})[\\/]?",
-  "readOnly": true
+  "pattern": "^http[s]?:\\/\\/.+?\\/organizer[s]?\\/([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12})[\\/]?"
 }

--- a/projects/uitdatabank/models/place-@id.json
+++ b/projects/uitdatabank/models/place-@id.json
@@ -4,7 +4,6 @@
   "format": "uri",
   "pattern": "^http[s]?:\\/\\/.+?\\/place[s]?\\/([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12})[\\/]?",
   "description": "A unique URI that acts as globally unique ID for the [place](./place.json). Based on JSON-LD node identifiers. https://www.w3.org/TR/json-ld/#node-identifiers",
-  "readOnly": true,
   "examples": [
     "https://io-test.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3"
   ]

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -812,12 +812,12 @@
                 "$ref": "../models/event-attendanceMode-put.json"
               },
               "examples": {
-                "Example Online": {
+                "Online": {
                   "value": {
                     "attendanceMode": "online"
                   }
                 },
-                "Example offline": {
+                "Offline": {
                   "value": {
                     "attendanceMode": "offline",
                     "location": "https://io-test.uitdatabank.be/place/85b04295-479c-40f5-b3dd-469dfb4387b3"


### PR DESCRIPTION
### Fixed

- Fixed the `location` property being hidden on the "attendanceMode - update" endpoint documentation. This was caused by the referenced `place.@id` being `readOnly`.

---

Ticket: https://jira.uitdatabank.be/browse/III-5162
