### PR TITLE
Fix casing of UiTiD

### DIFF
--- a/projects/authentication/docs/client-access-token.md
+++ b/projects/authentication/docs/client-access-token.md
@@ -6,7 +6,7 @@ The client can request a token on publiq's authorization server with its client 
 
 The token serves as proof of identity of the client, in other words your backend system. Because browsers and native applications cannot securely store the necessary client secret, they must not use client access tokens. A possible alternative in this case would be using [user access tokens](./user-access-token.md) with the PKCE flow.
 
-If your browser or native application cannot work with user logins via publiq's UiTID, you may also send requests from your frontend application to your own backend, and make API requests from there with a client access token. Note that you will be responsible to determine who may or may not access your backend to prevent abuse.
+If your browser or native application cannot work with user logins via publiq's UiTiD, you may also send requests from your frontend application to your own backend, and make API requests from there with a client access token. Note that you will be responsible to determine who may or may not access your backend to prevent abuse.
 
 > Not sure if client access tokens are the right authentication method for you, or which APIs support it? See our [overview of authentication methods](./methods.md) to get a brief summary of every method and a list of support APIs.
 

--- a/projects/authentication/docs/methods.md
+++ b/projects/authentication/docs/methods.md
@@ -61,11 +61,11 @@ API endpoints that support the authentication of an API client with a client id 
 
 👉 [Learn more about client access tokens](./client-access-token.md)
 
-### User access tokens (login via UiTID)
+### User access tokens (login via UiTiD)
 
 API endpoints that support authentication as a user use [user access tokens](./user-access-token.md).
 
-Usually used in situations where a user will log in through publiq's **UiTID** service and your application will then make requests in that user's name.
+Usually used in situations where a user will log in through publiq's **UiTiD** service and your application will then make requests in that user's name.
 
 * ✅ Suitable for frontend applications
 * ✅ Suitable for backend applications

--- a/projects/authentication/docs/user-access-token.md
+++ b/projects/authentication/docs/user-access-token.md
@@ -1,6 +1,6 @@
-# User access token (login via UiTID)
+# User access token (login via UiTiD)
 
-User access tokens are used to communicate with a publiq API in the name of a user **logged in through UiTID**, and can be requested through one of two ways depending on the type of application that you're building.
+User access tokens are used to communicate with a publiq API in the name of a user **logged in through UiTiD**, and can be requested through one of two ways depending on the type of application that you're building.
 
 Both flows are standard [OAuth2](https://oauth.net/2/) flows and work largely the same. In both cases you will redirect the user to the authorization server where they can login. Afterward, the user will be redirected back to your application and you will receive an authorization code. With this code you can request a user access token on the authorization server.
 
@@ -86,7 +86,7 @@ Note that:
 
 The `/authorize` URL supports more parameters than the ones used in this example. See [login parameters](#login-parameters) for more info.
 
-The authorization server will then show the UiTID login form (step 3), and the user logs in (step 4).
+The authorization server will then show the UiTiD login form (step 3), and the user logs in (step 4).
 
 After a successful login the authorization server will redirect the user back to the given `redirect_uri`, with an extra `code` URL parameter (step 5). So the redirect URL will look like:
 
@@ -233,7 +233,7 @@ Note that:
 
 The `/authorize` URL supports more parameters than the ones used in this example. See [login parameters](#login-parameters) for more info.
 
-The authorization server will then show the UiTID login form (step 4), and the user logs in (step 5).
+The authorization server will then show the UiTiD login form (step 4), and the user logs in (step 5).
 
 After a successful login the authorization server will redirect the user back to the given `redirect_uri`, with an extra `code` URL parameter (step 6). So the redirect URL will look like:
 
@@ -354,7 +354,7 @@ Response JSON example:
 
 ```json
 {
-    "sub": "google-oauth2|108326107941343586958", # User's UiTID v2 id, always present
+    "sub": "google-oauth2|108326107941343586958", # User's UiTiD v2 id, always present
     "https://publiq.be/first_name": "John", # User's first name, Always present
     "email": "john.doe@example.com", # Included if email scope was requested
     "email_verified": true # Included if email scope was requested

--- a/projects/authentication/toc.json
+++ b/projects/authentication/toc.json
@@ -42,7 +42,7 @@
     },
     {
       "type": "item",
-      "title": "User access token (login via UiTID)",
+      "title": "User access token (login via UiTiD)",
       "uri": "docs/user-access-token.md",
       "slug": "methods/user-access-token"
     },

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -1734,11 +1734,11 @@
                       },
                       "apiKey": {
                         "type": "string",
-                        "description": "API key of the UiTID v1 consumer that made the change (if it was an UiTID v1 consumer)."
+                        "description": "API key of the UiTiD v1 consumer that made the change (if it was an UiTiD v1 consumer)."
                       },
                       "consumerName": {
                         "type": "string",
-                        "description": "Name of the UiTID v1 consumer that made the change (if it was an UiTID v1 consumer)."
+                        "description": "Name of the UiTiD v1 consumer that made the change (if it was an UiTiD v1 consumer)."
                       }
                     },
                     "required": [
@@ -1760,7 +1760,7 @@
                       }
                     ]
                   },
-                  "UiTID v1 consumer": {
+                  "UiTiD v1 consumer": {
                     "value": [
                       {
                         "date": "2021-10-04T09:40:59+00:00",
@@ -4854,11 +4854,11 @@
                       },
                       "apiKey": {
                         "type": "string",
-                        "description": "API key of the UiTID v1 consumer that made the change (if it was an UiTID v1 consumer)."
+                        "description": "API key of the UiTiD v1 consumer that made the change (if it was an UiTiD v1 consumer)."
                       },
                       "consumerName": {
                         "type": "string",
-                        "description": "Name of the UiTID v1 consumer that made the change (if it was an UiTID v1 consumer)."
+                        "description": "Name of the UiTiD v1 consumer that made the change (if it was an UiTiD v1 consumer)."
                       }
                     },
                     "required": [
@@ -4880,7 +4880,7 @@
                       }
                     ]
                   },
-                  "UiTID v1 consumer": {
+                  "UiTiD v1 consumer": {
                     "value": [
                       {
                         "date": "2021-10-04T09:40:59+00:00",

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -1210,7 +1210,7 @@
         },
         "in": "query",
         "name": "creator",
-        "description": "Returns only results that have a creator with the given user identifier. Due to historic reasons and evolutions in the id management systems, a user identifier can be one of: a UUID (for creators that had an UiTID v1), an Auth0 user id (for new UiTID v2 creators), or in some very old cases even an email address or nickname. (No new events or places are created with an email address or nickname as creator.) Can also be a client id suffixed with `@clients` in the case of results created with a client access token instead of a user access token."
+        "description": "Returns only results that have a creator with the given user identifier. Due to historic reasons and evolutions in the id management systems, a user identifier can be one of: a UUID (for creators that had an UiTiD v1), an Auth0 user id (for new UiTiD v2 creators), or in some very old cases even an email address or nickname. (No new events or places are created with an email address or nickname as creator.) Can also be a client id suffixed with `@clients` in the case of results created with a client access token instead of a user access token."
       },
       "dateFrom": {
         "schema": {

--- a/projects/uitpas/docs/registering-events.md
+++ b/projects/uitpas/docs/registering-events.md
@@ -112,7 +112,7 @@ Registering an UiTPAS event in UiTdatabank's user interface takes just 3 steps!
 
 ### 1. Creating a new event
 
-Start by logging in on UiTdatabank with an existing UiTID account, or create one for free if you don't have one yet. Afterward you can immediately start entering events.
+Start by logging in on UiTdatabank with an existing UiTiD account, or create one for free if you don't have one yet. Afterward you can immediately start entering events.
 
 You can find more info in [our helpdesk article](https://helpdesk.publiq.be/hc/nl/articles/360016331140-Hulp-bij-het-invoeren-van-een-evenement) creating events in UiTdatabank.
 

--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -52,7 +52,7 @@
       "name": "Ticket sales"
     },
     {
-      "name": "UiTID"
+      "name": "UiTiD"
     }
   ],
   "paths": {
@@ -1484,7 +1484,7 @@
     "/passholders/me/uitid/registration-token": {
       "parameters": [],
       "get": {
-        "summary": "Retrieve UiTID registration token",
+        "summary": "Retrieve UiTiD registration token",
         "operationId": "get-uitid-passholder-registration-token",
         "responses": {
           "200": {
@@ -1512,7 +1512,7 @@
                 }
               }
             },
-            "description": "OK\n\nThe passholder can proceed UiTID registration."
+            "description": "OK\n\nThe passholder can proceed UiTiD registration."
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -1541,7 +1541,7 @@
             }
           }
         },
-        "description": "This is step 1 of the process to register an UiTPAS passholder in UiTID using their UiTPAS number and date of birth. It is used to retrieve an UiTID registration token for the passholder. If the passholder already has a token via an email they received to register in UiTID, this step can be skipped.\n\nThis endpoint uses HTTP Basic Authentication using:\n* Username: uitpasNumber \n* Password: dateOfBirth in the form yyyy-mm-dd\n\nIn summary, this header should look like: \n\n```\nAuthorization: Basic base64(uitpasNumber+dateOfBirth)\n```\n\nThe response will contain a `token` property that can be used in step 2 of the process, [retrieving the UiTID registration status](/reference/uitpas.json/paths/~1passholders~1me~1uitid~1status/get).\n\nThis caller of this method is identified with [client identification](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NDY5-client-identification) and does not require any permissions, but please note this endpoint is rate-limited on IP address to prevent abuse.",
+        "description": "This is step 1 of the process to register an UiTPAS passholder in UiTiD using their UiTPAS number and date of birth. It is used to retrieve an UiTiD registration token for the passholder. If the passholder already has a token via an email they received to register in UiTiD, this step can be skipped.\n\nThis endpoint uses HTTP Basic Authentication using:\n* Username: uitpasNumber \n* Password: dateOfBirth in the form yyyy-mm-dd\n\nIn summary, this header should look like: \n\n```\nAuthorization: Basic base64(uitpasNumber+dateOfBirth)\n```\n\nThe response will contain a `token` property that can be used in step 2 of the process, [retrieving the UiTiD registration status](/reference/uitpas.json/paths/~1passholders~1me~1uitid~1status/get).\n\nThis caller of this method is identified with [client identification](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NDY5-client-identification) and does not require any permissions, but please note this endpoint is rate-limited on IP address to prevent abuse.",
         "parameters": [
           {
             "schema": {
@@ -1570,7 +1570,7 @@
     "/passholders/me/uitid/status": {
       "parameters": [],
       "get": {
-        "summary": "Retrieve UiTID registration status",
+        "summary": "Retrieve UiTiD registration status",
         "operationId": "get-uitid-passholder-status",
         "responses": {
           "200": {
@@ -1626,7 +1626,7 @@
                 }
               }
             },
-            "description": "OK\n\nThe passholder can proceed UiTID registration."
+            "description": "OK\n\nThe passholder can proceed UiTiD registration."
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -1655,7 +1655,7 @@
             }
           }
         },
-        "description": "Retrieves the UiTID registration status of a passholder. This is step 2 in the process of registering an UiTPAS passholder in UiTID.\n\nThis endpoint requires a registation token in the `x-registration-token` header. A client can obtain such a token using [`GET /passholders/me/uitid/registration-token`](/reference/uitpas.json/paths/~1passholders~1me~1uitid~1registration-token/get). Alternatively, a token may already be available to the client because the user may have received an email link including it.\n\nBased on the state value, the client can proceed in 2 ways:\n\n- If state is `UNREGISTERED`\n\nThe passholder can proceed to step 3, [retrieving the UiTID email address status](/reference/uitpas.json/paths/~1uitid~1emails~1{email}/get).\n\nThe response can include the linked `email` address of the passholder if one is known. This can be used in the next step of the registration process ([`GET /uitid/emails/{email}`](/reference/uitpas.json/paths/~1uitid~1emails~1{email}/get)). If no email address is included, the client should prompt the user to enter their email address first before proceeding to step 3.\n\n- If state is `REGISTERED` \n\nThe passholder is already `REGISTERED` so the user must continue by authenticating instead. The `email` address field contains the email address of the linked UiTID account that should be used to authenticate.\n\n\nThis caller of this method, identified with [client identification](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NDY5-client-identification) does not require any permissions.",
+        "description": "Retrieves the UiTiD registration status of a passholder. This is step 2 in the process of registering an UiTPAS passholder in UiTiD.\n\nThis endpoint requires a registation token in the `x-registration-token` header. A client can obtain such a token using [`GET /passholders/me/uitid/registration-token`](/reference/uitpas.json/paths/~1passholders~1me~1uitid~1registration-token/get). Alternatively, a token may already be available to the client because the user may have received an email link including it.\n\nBased on the state value, the client can proceed in 2 ways:\n\n- If state is `UNREGISTERED`\n\nThe passholder can proceed to step 3, [retrieving the UiTiD email address status](/reference/uitpas.json/paths/~1uitid~1emails~1{email}/get).\n\nThe response can include the linked `email` address of the passholder if one is known. This can be used in the next step of the registration process ([`GET /uitid/emails/{email}`](/reference/uitpas.json/paths/~1uitid~1emails~1{email}/get)). If no email address is included, the client should prompt the user to enter their email address first before proceeding to step 3.\n\n- If state is `REGISTERED` \n\nThe passholder is already `REGISTERED` so the user must continue by authenticating instead. The `email` address field contains the email address of the linked UiTiD account that should be used to authenticate.\n\n\nThis caller of this method, identified with [client identification](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NDY5-client-identification) does not require any permissions.",
         "parameters": [
           {
             "schema": {
@@ -1694,7 +1694,7 @@
         }
       ],
       "get": {
-        "summary": "Retrieve UiTID email address status",
+        "summary": "Retrieve UiTiD email address status",
         "operationId": "get-uitid-email",
         "responses": {
           "200": {
@@ -1710,7 +1710,7 @@
                         "UITID_REGISTERED",
                         "UITPAS_ALREADY_LINKED"
                       ],
-                      "description": "* `UITPAS_ALREADY_LINKED` : the user cannot use this email address to register another UiTPAS\n* `UITID_UNREGISTERED` : the user can use this email address to register their UiTPAS but must register on UiTID first\n* `UITID_REGISTERED` : the user can use this email address to register their UiTPAS but must login on UiTID first"
+                      "description": "* `UITPAS_ALREADY_LINKED` : the user cannot use this email address to register another UiTPAS\n* `UITID_UNREGISTERED` : the user can use this email address to register their UiTPAS but must register on UiTiD first\n* `UITID_REGISTERED` : the user can use this email address to register their UiTPAS but must login on UiTiD first"
                     }
                   },
                   "required": [
@@ -1756,9 +1756,9 @@
             }
           }
         },
-        "description": "Retrieves the email address status in UiTPAS and UiTID for a given email address. This is step 3 in the process of registering an UiTPAS passholder in UiTID.\n\nThe response contains a `state` property which can be one of the following values:\n\n* `UITPAS_ALREADY_LINKED` : the user cannot use this email address to register another UiTPAS\n* `UITID_UNREGISTERED` : the user can use this email address to register their UiTPAS but must register on UiTID first\n* `UITID_REGISTERED` : the user can use this email address to register their UiTPAS but must login on UiTID first\n\nAfter [UiTID authentication](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token) the client should proceed to step 4 of the process, [registering UiTID for the passholder](/reference/uitpas.json/paths/~1passholders~1me~1uitid/put).\n\nThis caller of this method, identified with [client identification](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NDY5-client-identification), does not require any permissions but please note this endpoint is rate-limited on IP address to prevent abuse.",
+        "description": "Retrieves the email address status in UiTPAS and UiTiD for a given email address. This is step 3 in the process of registering an UiTPAS passholder in UiTiD.\n\nThe response contains a `state` property which can be one of the following values:\n\n* `UITPAS_ALREADY_LINKED` : the user cannot use this email address to register another UiTPAS\n* `UITID_UNREGISTERED` : the user can use this email address to register their UiTPAS but must register on UiTiD first\n* `UITID_REGISTERED` : the user can use this email address to register their UiTPAS but must login on UiTiD first\n\nAfter [UiTiD authentication](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token) the client should proceed to step 4 of the process, [registering UiTiD for the passholder](/reference/uitpas.json/paths/~1passholders~1me~1uitid/put).\n\nThis caller of this method, identified with [client identification](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NDY5-client-identification), does not require any permissions but please note this endpoint is rate-limited on IP address to prevent abuse.",
         "tags": [
-          "UiTID"
+          "UiTiD"
         ],
         "parameters": [],
         "security": [
@@ -2052,7 +2052,7 @@
     "/passholders/me/uitid": {
       "parameters": [],
       "put": {
-        "summary": "Register UiTID for passholder",
+        "summary": "Register UiTiD for passholder",
         "operationId": "register-uitid-passholder",
         "responses": {
           "201": {
@@ -2075,7 +2075,7 @@
             "$ref": "#/components/responses/Forbidden"
           }
         },
-        "description": "Registers the UiTID for this passholder. This is step 4, and the final step, in the process of registering an UiTPAS passholder in UiTID.\n\nThis request requires an `Authorization` header with the [user access token](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token) of an authenticated UiTID *and* it requires a `x-registration-token` header containing a valid registration token of the passholder.\n\nA user access token of a client with `PASSHOLDER_REGISTER_UITID` permission is mandatory.",
+        "description": "Registers the UiTiD for this passholder. This is step 4, and the final step, in the process of registering an UiTPAS passholder in UiTiD.\n\nThis request requires an `Authorization` header with the [user access token](https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token) of an authenticated UiTiD *and* it requires a `x-registration-token` header containing a valid registration token of the passholder.\n\nA user access token of a client with `PASSHOLDER_REGISTER_UITID` permission is mandatory.",
         "security": [
           {
             "USER_ACCESS_TOKEN": []
@@ -2186,7 +2186,7 @@
           }
         },
         "operationId": "get-passholders-me",
-        "description": "Allows users to retrieve their passholder using a user access token.\n\nA user access token of a client with `PASSHOLDER_SELF_READ` permission is mandatory. The passholder is retrieved by `inszNumber` if the access token contains the custom claim `https://publiq.be/rrn` (i.e. user has logged in using connection ACM), or by linked UiTID user (`sub` or `https://publiq.be/uitidv1id` claim of the user access token).",
+        "description": "Allows users to retrieve their passholder using a user access token.\n\nA user access token of a client with `PASSHOLDER_SELF_READ` permission is mandatory. The passholder is retrieved by `inszNumber` if the access token contains the custom claim `https://publiq.be/rrn` (i.e. user has logged in using connection ACM), or by linked UiTiD user (`sub` or `https://publiq.be/uitidv1id` claim of the user access token).",
         "security": [
           {
             "USER_ACCESS_TOKEN": []
@@ -5080,7 +5080,7 @@
               "REGISTERED",
               "UNREGISTERED"
             ],
-            "description": "Whether or not the passholder has a an UiTID registered. This field is always available in responses.",
+            "description": "Whether or not the passholder has a an UiTiD registered. This field is always available in responses.",
             "readOnly": true
           },
           "address": {


### PR DESCRIPTION
### Fixed

- Fixed casing of UiTiD in all occurrences where it was incorrectly written as UiTID

---

This seems like a mistake that a lot of people (including me) make. (I also see it a lot in other communication from colleagues). I just happened to notice at some point that it's actually supposed to be UiTiD.

See for example the casing in the logo: 
![image](https://user-images.githubusercontent.com/959026/211014916-2108d27f-e3d2-4ca6-93d3-eb77ce8961ec.png)

On the helpdesk website: https://helpdesk.uitid.be/hc/nl-be

And on https://profile.uitid.be/nl/home (for example in the title of the window/tab), "Vragen over UiTiD?", etc.
