### PR TITLE
UiTdatabank: Replace dead link

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -24,7 +24,8 @@
         "skipUrlPatterns": [
             "https://helpdesk.publiq.be",
             "https://www.uitinhasselt.be",
-            "https://github.com/cultuurnet/udb3-acceptance-tests"
+            "https://github.com/cultuurnet/udb3-acceptance-tests",
+            "https://overheid.vlaanderen.be/wedstrijd-api-van-het-jaar-2019"
         ]
     },
     "remark-validate-links": null,

--- a/.remarkrc
+++ b/.remarkrc
@@ -24,8 +24,7 @@
         "skipUrlPatterns": [
             "https://helpdesk.publiq.be",
             "https://www.uitinhasselt.be",
-            "https://github.com/cultuurnet/udb3-acceptance-tests",
-            "https://overheid.vlaanderen.be/wedstrijd-api-van-het-jaar-2019"
+            "https://github.com/cultuurnet/udb3-acceptance-tests"
         ]
     },
     "remark-validate-links": null,

--- a/projects/uitdatabank/docs/introduction.md
+++ b/projects/uitdatabank/docs/introduction.md
@@ -14,7 +14,7 @@ Interested in setting up your own calendar aimed at a specific target group? Aro
 
 The UiTdatabank APIs follow the [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) principles. Our APIs have predictable resource-oriented URLs, accept and return [JSON](https://www.json.org/json-en.html)-encoded data, and use standard HTTP methods, status codes and [authentication](https://docs.publiq.be/docs/authentication).
 
-In 2019, the UiTdatabank APIs won the ["API of the year" award](https://overheid.vlaanderen.be/wedstrijd-api-van-het-jaar-2019). Since then, we have continuously been improving them while also maintaining compatibility with all existing integrations.
+In 2019, the UiTdatabank APIs won the ["API of the year" award](https://www.publiq.be/nl/nieuws/de-uitdatabank-wint-de-award-voor-api-van-het-jaar). Since then, we have continuously been improving them while also maintaining compatibility with all existing integrations.
 
 In our documentation you will find:
 


### PR DESCRIPTION
### Fixed

- Replaced link to `overheid.vlaanderen.be` about API of the year award (2019) that is suddenly dead
