### PR TITLE
API-19 Update contact info

### DIFF
--- a/projects/_template/reference/example-api.json
+++ b/projects/_template/reference/example-api.json
@@ -6,7 +6,7 @@
     "description": "This is an example OpenAPI file. It comes with the right authentication for publiq APIs, and some standard error responses. Feel free to edit or remove it!",
     "contact": {
       "name": "publiq helpdesk",
-      "email": "vragen@publiq.be",
+      "email": "technical-support@publiq.be",
       "url": "https://docs.publiq.be"
     }
   },

--- a/projects/authentication/docs/cors.md
+++ b/projects/authentication/docs/cors.md
@@ -6,7 +6,7 @@
 
 If you encounter CORS issues after all, double check what headers you are trying to include in your requests. Some APIs may only allow headers that they actually use like `authorization` for tokens, `content-type` and `accept` for content negotiation, etc. Try to keep the headers in your request to the ones that are actually required / useful.
 
-If this doesn't solve the issue contact our support for more help. The API you are using might need to be updated to allow requests from any origin, or there might be a bug in the CORS logic on that specific API. Remember to include a copy of the complete request you are trying to send (for example as `HAR` or `curl`), and ideally also include the complete `OPTIONS` request if the browser is doing a preflight request.
+If this doesn't solve the issue [contact our support](https://docs.publiq.be/#contact-us) for more help. The API you are using might need to be updated to allow requests from any origin, or there might be a bug in the CORS logic on that specific API. Remember to include a copy of the complete request you are trying to send (for example as `HAR` or `curl`), and ideally also include the complete `OPTIONS` request if the browser is doing a preflight request.
 
 ## What is CORS?
 

--- a/projects/authentication/docs/requesting-credentials.md
+++ b/projects/authentication/docs/requesting-credentials.md
@@ -19,7 +19,7 @@ Support for the standardized authentication methods documented in this space has
 Want to start integrating with UiTdatabank right now? There are three options:
 
 1. If you need to integrate with both the **UiTPAS API and UiTdatabank API(s)**, you can follow the procedure of requesting credentials for the UiTPAS API and mention that you also require access to the UiTdatabank APIs. We will then provide you with a set of credentials that can access both.
-2. **Or**, contact us at <vragen@uitdatabank.be> to get a client id and client secret for UiTdatabank to start using the new authentication mechanism already. Once you have your client id and secret you can use the standard authentication methods described here.
+2. **Or**, [contact us](https://docs.publiq.be/#contact-us) to get a client id and client secret for UiTdatabank to start using the new authentication mechanism already. Once you have your client id and secret you can use the standard authentication methods described here.
 3. **Or**, register your project at [Projectaanvraag](https://projectaanvraag.uitdatabank.be) to automatically get a test **API key** that you can use as described on the [EntryAPI authentication documentation](https://documentatie.uitdatabank.be/content/entry_api_3/latest/authentication.html) in our older documentation portal. While this way of authentication will be phased out in the future for new integrators, it will still be supported for existing integrations for the foreseeable future.
 
 Aside from the authentication method all API operations on the UiTdatabank APIs work exactly the same whether you have a client id and secret, or an API key.

--- a/projects/museumpassmusees/reference/partner-api.json
+++ b/projects/museumpassmusees/reference/partner-api.json
@@ -6,7 +6,7 @@
     "description": "With the museumPASSmusées Partner API you can look up the card of a passholder and check if they are allowed to visit your museum and register their visit so your museum gets reimbursed for it.\n\nIt also enables you to sell museumPASSmusées subscriptions to new passholders by generating voucher codes and selling those to new passholders to use in the online order process on [museumpassmusees.be](https://museumpassmusees.be).\n\n## Postman\n\n<!-- focus: false -->\n\n[![Download postman collection](https://postman.publiq.be/postman-download.svg)](https://postman.publiq.be/?api=mpm-partner-api)\n\nDo you already have a **client id** and **client secret**?\nDownload a personalized Postman collection to start making requests in seconds!",
     "contact": {
       "name": "publiq helpdesk",
-      "email": "vragen@publiq.be",
+      "email": "technical-support@publiq.be",
       "url": "https://docs.publiq.be"
     }
   },

--- a/projects/uitdatabank/docs/entry-api/requirements-before-going-live.md
+++ b/projects/uitdatabank/docs/entry-api/requirements-before-going-live.md
@@ -19,7 +19,7 @@ Once you've obtained your personal test credentials you can start with the devel
 
 ## 2. Validation by publiq vzw
 
-As soon as you have finished developing your integration with the Entry API, you send a minimum of 5 of events to our test environment. You contact us via `vragen@publiq.be` with the email subject "content check". In the email you give us the identifiers of the created test events. We will then validate your integration as soon as possible.
+As soon as you have finished developing your integration with the Entry API, you send a minimum of 5 of events to our test environment. [Contact us](https://docs.publiq.be/#contact-us) with the email subject "content check". In the email you give us the identifiers of the created test events. We will then validate your integration as soon as possible.
 
 In this validation process we assess the integration in two manners:
 

--- a/projects/uitdatabank/docs/taxonomy-api/terms.md
+++ b/projects/uitdatabank/docs/taxonomy-api/terms.md
@@ -45,7 +45,7 @@ Scope: `events`, `places`
 
 A term with domain `facility` describes specific accessibility facilities for people with disabilities, e.g. accessible sanitary facilities. Some facilities apply on locations only, others on events only. Check the term's `scope` property to see if it applies to an event or a place.
 
-> The list of accessibility features below has been compiled in consultation with Inter - Toegankelijk Vlaanderen. These facilities are behind a permission model and can only be added by trusted partners. If you are interested in enriching your own event data or data from third parties with facility information, please contact <vragen@publiq.be>.
+> The list of accessibility features below has been compiled in consultation with Inter - Toegankelijk Vlaanderen. These facilities are behind a permission model and can only be added by trusted partners. If you are interested in enriching your own event data or data from third parties with facility information, please contact <partnerships@publiq.be>.
 
 ### Location-level facilities
 

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -6,7 +6,7 @@
     "description": "With UiTdatabank's Entry API you can create new events, places and organizers, and add extra info to them with specific requests to add/update properties. For example there are operations to add a label, remove a label, add an image, and so on.",
     "contact": {
       "name": "publiq helpdesk",
-      "email": "vragen@publiq.be",
+      "email": "technical-support@publiq.be",
       "url": "https://docs.publiq.be"
     }
   },

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -6,7 +6,7 @@
     "description": "With UiTdatabank's Search API you can search events, places and organizers.",
     "contact": {
       "name": "publiq helpdesk",
-      "email": "vragen@publiq.be",
+      "email": "technical-support@publiq.be",
       "url": "https://docs.publiq.be"
     }
   },

--- a/projects/uitdatabank/reference/taxonomy.json
+++ b/projects/uitdatabank/reference/taxonomy.json
@@ -6,7 +6,7 @@
     "description": "With UiTdatabank's taxonomy API you can retrieve lists of taxonomy terms like event types, place types, themes and facilities.",
     "contact": {
       "name": "publiq helpdesk",
-      "email": "vragen@publiq.be",
+      "email": "technical-support@publiq.be",
       "url": "https://docs.publiq.be"
     }
   },

--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -5,7 +5,7 @@
     "version": "4.0",
     "contact": {
       "name": "publiq helpdesk",
-      "email": "vragen@publiq.be",
+      "email": "technical-support@publiq.be",
       "url": "https://docs.publiq.be"
     },
     "description": "With UiTPAS API 4.0 you can retrieve ticket sale prices for specific UiTPAS numbers, and register ticket sales for specific UiTPAS numbers.\n\nFuture versions will also include support for more features like saving points and exchanging them for benefits.\n\n## Postman\n\n<!-- focus: false -->\n\n[![Download postman collection](https://postman.publiq.be/postman-download.svg)](https://postman.publiq.be/?api=uitpas-api)\n\nDo you already have a **client id** and **client secret**?\nDownload a personalized Postman collection to start making requests in seconds!"


### PR DESCRIPTION
### Changed

- Updated contact email address in the OpenAPI files
- Added missing link to contact info on CORS page
- Replaced vragen@publiq.be links with link to landing page with contact info
- Replaced vragen@publiq.be email address to use facility terms with partnerships@publiq.be

---

Ticket: https://jira.uitdatabank.be/browse/API-19

Note: Some pages still contain direct links to the email addresses partnerships@publiq.be and content.cultuurkuur@publiq.be for specific messages not related to technical issues/questions. To be discussed if we also replace those with links to the landing page (if we also mention those there)
