### PR TITLE
Widgets links fixes

### DIFF
--- a/projects/widgets/docs/configureren/starten-met-configureren.md
+++ b/projects/widgets/docs/configureren/starten-met-configureren.md
@@ -32,7 +32,7 @@ Binnen dit template kies je zelf welke blokken je toevoegt en je dus kan configu
 Deze templates bevatten 4 verschillende blokken, die je elk apart dient te configureren:
 
 * [HTML](./html.md)
-* [Verfijingen](./verfijningen.md)
+* [Verfijningen](./verfijningen.md)
 * [Zoekbox](./zoekbox.md)
 * [Zoekresultaten](./zoekresultaten.md)
 

--- a/projects/widgets/docs/configureren/starten-met-configureren.md
+++ b/projects/widgets/docs/configureren/starten-met-configureren.md
@@ -31,10 +31,10 @@ Binnen dit template kies je zelf welke blokken je toevoegt en je dus kan configu
 
 Deze templates bevatten 4 verschillende blokken, die je elk apart dient te configureren:
 
-* [HTML](/html.md)
-* [Verfijingen](/verfijningen.md)
-* [Zoekbox](/zoekbox.md)
-* [Zoekresultaten](/zoekresultaten.md)
+* [HTML](./html.md)
+* [Verfijingen](./verfijningen.md)
+* [Zoekbox](./zoekbox.md)
+* [Zoekresultaten](./zoekresultaten.md)
 
 ## Tips template
 

--- a/projects/widgets/toc.json
+++ b/projects/widgets/toc.json
@@ -36,7 +36,7 @@
           "type": "item",
           "title": "Starten met configureren",
           "uri": "/docs/configureren/starten-met-configureren.md",
-          "slug": "starten-met-configureren/html"
+          "slug": "configureren/starten"
         },
         {
           "type": "item",


### PR DESCRIPTION
### Fixed

- Fixed slug of "Starten met configureren" page
- Fixed broken links to other "configureren" pages on "Starten met configureren"
- Fixed typo in "Verfijningen" link
