### PR TITLE
Fix broken links in UiTPAS guides

### DIFF
--- a/projects/uitpas/docs/registering-ticket-sales-group.md
+++ b/projects/uitpas/docs/registering-ticket-sales-group.md
@@ -1,6 +1,6 @@
 # Registering ticket sales for group passes
 
-This mini-guide illustrates how to register UiTPAS discounted ticket sales for a group pass. It builds upon the [Registering ticket sales guide](/docs/registering-ticket-sales-group.md) which you need to read first to learn more about authentication, the work flow and registering events.
+This mini-guide illustrates how to register UiTPAS discounted ticket sales for a group pass. It builds upon the [Registering ticket sales guide](./registering-ticket-sales.md) which you need to read first to learn more about authentication, the work flow and registering events.
 
 > ##### What is a group pass?
 >
@@ -22,7 +22,7 @@ Host: https://api.uitpas.be
 Authorization: Bearer YOUR_CLIENT_ACCESS_TOKEN'
 ```
 
-Have a look at the [test dataset](/docs/test-dataset) for more sample passholders or events.
+Have a look at the [test dataset](./test-dataset.md) for more sample passholders or events.
 
 Example response:
 
@@ -93,7 +93,7 @@ Authorization: Bearer YOUR_ACCESS_TOKEN'
 ]
 ```
 
-Have a look at the [test dataset](/docs/test-dataset) for more sample passholders or events.
+Have a look at the [test dataset](./test-dataset.md) for more sample passholders or events.
 
 For more information about each property, see the documentation for the [POST /ticket-sales](/reference/uitpas.json/paths/~1ticket-sales/post) endpoint.
 
@@ -152,4 +152,4 @@ If for some reason you need to [cancel the ticket sale registration](/reference/
 
 ### Frequently asked questions
 
-Having questions? Check out our [FAQ](/docs/faq)!
+Having questions? Check out our [FAQ](./faq.md)!

--- a/projects/uitpas/docs/registering-ticket-sales-multiple.md
+++ b/projects/uitpas/docs/registering-ticket-sales-multiple.md
@@ -1,6 +1,6 @@
 # Registering multiple ticket sales at once
 
-This mini-guide illustrates how to register UiTPAS discounted ticket sales for multiple tickets at once. It builds upon the [Registering ticket sales guide](/docs/registering-ticket-sales-group.md) which you need to read first to learn more about authentication, the work flow and registering events.
+This mini-guide illustrates how to register UiTPAS discounted ticket sales for multiple tickets at once. It builds upon the [Registering ticket sales guide](./registering-ticket-sales.md) which you need to read first to learn more about authentication, the work flow and registering events.
 
 ### 1. Determine possible UiTPAS tariffs
 
@@ -22,7 +22,7 @@ Host: https://api.uitpas.be
 Authorization: Bearer YOUR_CLIENT_ACCESS_TOKEN'
 ```
 
-Have a look at the [test dataset](/docs/test-dataset) for more sample passholders or events.
+Have a look at the [test dataset](./test-dataset.md) for more sample passholders or events.
 
 Example response:
 
@@ -155,4 +155,4 @@ If for some reason you need to [cancel the ticket sale registration](/reference/
 
 ### Frequently asked questions
 
-Having questions? Check out our [FAQ](/docs/faq)!
+Having questions? Check out our [FAQ](./faq.md)!

--- a/projects/uitpas/docs/registering-ticket-sales.md
+++ b/projects/uitpas/docs/registering-ticket-sales.md
@@ -62,7 +62,7 @@ Host: https://api.uitpas.be
 Authorization: Bearer YOUR_CLIENT_ACCESS_TOKEN'
 ```
 
-Have a look at the [test dataset](/docs/test-dataset) for more sample passholders or events.
+Have a look at the [test dataset](./test-dataset.md) for more sample passholders or events.
 
 Example response:
 
@@ -94,7 +94,7 @@ In this example the passholder can select two possible UiTPAS discounts. The soc
 
 > ##### remaining tickets at a tariff
 >
-> For regular passholders, the `remaining` value is always 1. Please refer to [registering ticket sales for group passes](/docs/registering-ticket-sales-group) for more information on group pass ticket sales.
+> For regular passholders, the `remaining` value is always 1. Please refer to [registering ticket sales for group passes](./registering-ticket-sales-group.md) for more information on group pass ticket sales.
 
 ### 5. Passholder selects a tariff
 
@@ -134,9 +134,9 @@ Authorization: Bearer YOUR_ACCESS_TOKEN'
 ]
 ```
 
-Have a look at the [test dataset](/docs/test-dataset) for more sample passholders or events.
+Have a look at the [test dataset](./test-dataset.md) for more sample passholders or events.
 
-As you can see, you can also include multiple ticket sale registrations at once. Read more about this in the [registering multiple ticket sales at once](/docs/registering-ticket-sales-multiple) mini guide.
+As you can see, you can also include multiple ticket sale registrations at once. Read more about this in the [registering multiple ticket sales at once](./registering-ticket-sales-multiple.md) mini guide.
 
 This can be helpful when you want to provide your passholders a way to buy multiple tickets at once.
 
@@ -180,4 +180,4 @@ If for some reason you need to [cancel the ticket sale registration](/reference/
 
 ### Frequently asked questions
 
-Having questions? Check out our [FAQ](/docs/faq)!
+Having questions? Check out our [FAQ](./faq.md)!


### PR DESCRIPTION
### Fixed

- Fixed various broken links in the UiTPAS guides. Not sure yet why these were not detected by the dead link checker. I also noticed it in the Widgets/UiTdatabank documentation sometimes, so it's not a unique problem.

---

You can check the links on the Stable version on Stoplight to see that they lead to 404s
