### PR TITLE
III-5108 School events tweaks

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/create-online.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-online.md
@@ -15,7 +15,7 @@ In this guide you will learn how to:
 
 As with regular events, anyone can create new online events in UiTdatabank by using either a user access token or a client access token.
 
-The user or client that created the event will become the `creator` of the online event, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
+The user or client that created the event will become its `creator`, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
 
 ## Creating an online event
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -109,11 +109,17 @@ In case of a [guided tours](#guided-tours) or [bookable event](#bookable-events)
 }
 ```
 
-### location in consultation with the school
+[School performances](#school-performances) should set the `calendarType` property to `single`, `multiple` or `periodic` depending on the schedule of the performance.
 
-In case of a [bookable event](#bookable-events) you must use the url of the "location in consultation with the school" as the value for the `location.@id` property in the `POST /events` request of the event(s) that you want to create.
+See the [guide about calendar info](../shared/calendar-info.md) for more details.
 
-**URLs**:
+### location
+
+In case of a [bookable event](#bookable-events) you must use the url of the *"Location in consultation with the school"* place as the value for the `location.@id` property in the `POST /events` request of the event(s) that you want to create.
+
+On the other hand, [school performances](#school-performances) and [guided tours](#guided-tours) must be linked to the place that they are happening at.
+
+**URLs for "location in consultation with school" places**:
 
 * Test environment: `https://io-test.uitdatabank.be/place/3b92c85b-a923-4895-85f5-ed056dae11e2`
 * Production environment: `https://io.uitdatabank.be/place/c3f9278e-228b-4199-8f9a-b9716a17e58f`

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -2,12 +2,6 @@
 stoplight-id: c7be5835e744b
 ---
 
-<!-- 
-  @todo 
-  Refer to the guide about creating new events first. 
-  Permissions: Who can create school events?
--->
-
 # School events
 
 School events are events that are specifically organized and intended for:

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -11,7 +11,7 @@ School events are events that are specifically organized and intended for:
 
 School events are published on [Cultuurkuur](https://www.cultuurkuur.be), but not on UiTinVlaanderen.
 
-Creating an online event is very similar to [creating a regular new event](./create.md), so it is recommended to read that guide first.
+Creating a school event is very similar to [creating a regular new event](./create.md), so it is recommended to read that guide first.
 
 > There is also a user interface available to enter school events, on <https://www.uitdatabank.be>. We recommend using this interface if you only organize a limited number of school events per year.
 >
@@ -21,7 +21,7 @@ Creating an online event is very similar to [creating a regular new event](./cre
 
 As with regular events, anyone can create new school events in UiTdatabank by using either a user access token or a client access token.
 
-The user or client that created the event will become the `creator` of the online event, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
+The user or client that created the event will become the `creator` of the school event, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
 
 ## Types
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -8,7 +8,7 @@ stoplight-id: c7be5835e744b
   Permissions: Who can create school events?
 -->
 
-# Creating a school event
+# School events
 
 School events are events that are specifically organized and intended for:
 
@@ -80,7 +80,7 @@ In order to create a bookable school event you must use
 * Test environment: `https://io-test.uitdatabank.be/place/3b92c85b-a923-4895-85f5-ed056dae11e2`
 * Production environment: `https://io.uitdatabank.be/place/c3f9278e-228b-4199-8f9a-b9716a17e58f`
 
-## How to create a school event
+## Creating a school event
 
 For the creation of school events several extra requirements apply:
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -21,7 +21,7 @@ Creating a school event is very similar to [creating a regular new event](./crea
 
 As with regular events, anyone can create new school events in UiTdatabank by using either a user access token or a client access token.
 
-The user or client that created the event will become the `creator` of the school event, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
+The user or client that created the event will become its `creator`, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
 
 ## Types
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -34,22 +34,12 @@ School performances are events of which both the date and the location is known 
 * ✅ date is known in advance
 * ✅ location is known in advance
 
-Since school performances both have a date and a location, you can create them in a very similar way to regular events:
-
-* you can use a calendarType of your preference (`single`, `multiple` or `periodic`)
-* for the location you must use the URL of an existing place as `location.@id` in the `POST /events` request of the event. More detailed documentation about reusing existing places can be found in [this guide](../places/finding-and-reusing-places.md).
-
 ### Guided tours
 
 Guided tours are events that have no specific date (or the date is not known in advance), but they do have a location. For example, a guided tour in the Royal Museum of Fine Arts Antwerp.
 
 * ❌ date is not known in advance
 * ✅ location is known in advance
-
-In order to create a guided school tour you must use:
-
-* calendarType `permanent`
-* the URL of an existing place as `location.@id` in the `POST /events` request of the event. More detailed documentation about reusing existing places can be found in [this guide](../places/finding-and-reusing-places.md).
 
 ### Bookable events
 
@@ -59,16 +49,6 @@ For example, as a school you can book Stijn Meuris for a school performance at y
 
 * ❌ date is not known in advance
 * ❌ location is not known in advance
-
-In order to create a bookable school event you must use
-
-* calendarType `permanent`
-* use the URL of the "location in consultation with the school" as `location.@id` in the `POST /events` request of the bookable events
-
-**URL of the location in consultation with the school**:
-
-* Test environment: `https://io-test.uitdatabank.be/place/3b92c85b-a923-4895-85f5-ed056dae11e2`
-* Production environment: `https://io.uitdatabank.be/place/c3f9278e-228b-4199-8f9a-b9716a17e58f`
 
 ## Creating a school event
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -13,7 +13,7 @@ School events are published on [Cultuurkuur](https://www.cultuurkuur.be), but no
 
 Creating a school event is very similar to [creating a regular new event](./create.md), so it is recommended to read that guide first.
 
-> There is also a user interface available to enter school events, on <https://www.uitdatabank.be>. We recommend using this interface if you only organize a limited number of school events per year.
+> There is also a user interface available to enter school events, on <https://www.uitdatabank.be>. We recommend using this interface, instead of building an API integration, if you only organize a limited number of school events per year.
 >
 > For questions about school events, please contact <content.cultuurkuur@publiq.be>.
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -76,13 +76,15 @@ In order to create a bookable school event you must use
 
 ## Creating a school event
 
-For the creation of school events several extra requirements apply:
+Creating a school event is the same as [creating a regular event](./create.md), but with some extra required properties:
 
-1. The `audienceType` must be set to `education`
-2. The event must have an `organizer` that has the `Cultuurkuur` label
-3. In case of a [guided tour](#guided-tours) or a [bookable event](#bookable-events): the `calendarType` must be set to `permanent`
-4. In case of a [bookable event](#bookable-events): the `location in consultation with the school` must be used for the location
-5. Every school event must have at least one label that indicates the education level of the target audience
+1. The `audience.audienceType` property must be set to `education`
+2. The event must be linked to an `organizer` that has the `Cultuurkuur` label
+3. In case of a [guided tour](#guided-tours) or a [bookable event](#bookable-events), the `calendarType` must be set to `permanent`
+4. In case of a [bookable event](#bookable-events), the `location in consultation with the school` must be used for the location
+5. The event must have at least one label that indicates the education level of the target audience
+
+We will go over these required properties in more detail below, followed by some examples.
 
 ### audienceType
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -134,6 +134,44 @@ On the other hand, [school performances](#school-performances) and [guided tours
 
 ### labels
 
+For school events, specific Cultuurkuur-related labels are mandatory. There are 3 different types of Cultuurkuur-related labels:
+
+1. **Target group labels** are used to specify whether the event is for students or for teachers.
+2. **Subject labels** are used to define the learning objective of the school event.
+3. **Education level labels** indicate to which education levels (grades) the school event is aimed at.
+
+#### Target group labels
+
+Target group labels are used to specify whether the event is for students or for teachers.
+
+> A school event must have **exactly one** target group label.
+| Target group | Label                      |
+| :----------- | :------------------------- |
+| Students     | `cultuurkuur_Leerlingen`   |
+| Teachers     | `cultuurkuur_leerkrachten` |
+
+#### Subject labels
+
+Subject labels are used to specify the learning objective of the school event.
+
+> A school event must have **at least one** subject label.
+| Subject                                     | Label                                                     |
+| :------------------------------------------ | :-------------------------------------------------------- |
+| Actief Burgerschap                          | `cultuurkuur_Actief Burgerschap`                          |
+| Duurzaamheid, natuur en milieu              | `cultuurkuur_Duurzaamheid, natuur en milieu`              |
+| Filosofie religie                           | `cultuurkuur_Filosofie-religie`                           |
+| Internationale - Europese thema's           | `cultuurkuur_Internationale - Europese thema's`           |
+| kunst en cultuur                            | `cultuurkuur_kunst-en-cultuur`                            |
+| Leren leren                                 | `cultuurkuur_Leren leren`                                 |
+| Lichamelijke, sociale en mentale gezondheid | `cultuurkuur_Lichamelijke, sociale en mentale gezondheid` |
+| Media                                       | `cultuurkuur_Media`                                       |
+| Mobiliteit                                  | `cultuurkuur_Mobiliteit`                                  |
+| Ondernemingszin                             | `cultuurkuur_Ondernemingszin`                             |
+| Taal                                        | `cultuurkuur_taal`                                        |
+| Wiskunde                                    | `cultuurkuur_Wiskunde`                                    |
+
+#### Education level labels
+
 Each school event must have **at least one** education level label.
 
 Education level labels indicate to which education levels (grades) the school event is aimed at.
@@ -145,7 +183,7 @@ There is a hierarchical relationship between the different education level label
 * If a level 4 label (e.g. `cultuurkuur_Kleuter-2-3-jaar`) is applicable on an event, the corresponding level 3, level 2 and level 1 label must also be added to the event: `cultuurkuur_Gewoon-kleuteronderwijs` (level 3), `cultuurkuur_Gewoon-basisonderwijs` (level 2) and `cultuurkuur_basisonderwijs` (level 1)
 * If only level 1 label is applicable (e.g. `cultuurkuur_Volwassenenonderwijs`), then it suffices to add only the level 1 label
 
-#### Level 1 labels
+##### Level 1 labels
 
 | Education level          | Label (level 1)                            |
 | :----------------------- | :----------------------------------------- |
@@ -155,7 +193,7 @@ There is a hierarchical relationship between the different education level label
 | Volwassenenonderwijs     | `cultuurkuur_Volwassenenonderwijs`         |
 | Deeltijds kunstonderwijs | `cultuurkuur_Deeltijds-kunstonderwijs-DKO` |
 
-#### Level 2 labels
+##### Level 2 labels
 
 > A level 2 label must always be combined with a level 1 label.
 
@@ -189,7 +227,7 @@ The following labels must always be combined with level 1 label `cultuurkuur_Dee
 | Muziek                          | `cultuurkuur_muziek`                          |
 | Woordkunst & drama              | `cultuurkuur_Woordkunst-drama`                |
 
-#### Level 3 labels
+##### Level 3 labels
 
 > A level 3 label must always be combined with both a level 1 label and a level 2 label.
 
@@ -233,7 +271,7 @@ The following level 3 labels must always be combined with:
 | Secundair na Secundair (Se-n-Se)                      | `cultuurkuur_Secundair-na-secundair-(Se-n-Se)`                    |
 | Onthaalonderwijs voor anderstalige nieuwkomers (OKAN) | `cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers-OKAN` |
 
-#### Level 4 labels
+##### Level 4 labels
 
 > A level 4 label must always be combined with both a level 1, level 2 and level 3 label.
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -21,6 +21,12 @@ School events are published on [Cultuurkuur](https://www.cultuurkuur.be), but no
 >
 > For questions about school events, please contact <content.cultuurkuur@publiq.be>.
 
+## Required permissions
+
+As with regular events, anyone can create new school events in UiTdatabank by using either a user access token or a client access token.
+
+The user or client that created the event will become the `creator` of the online event, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
+
 ## Types
 
 We distinguish 3 different types of school events:

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -308,7 +308,7 @@ The following level 4 labels must always be combined with
 
 ## Request body examples
 
-**school performance**
+### School performance
 
 Example of a theater performance aimed at toddlers of 3-4 years old in "hetpaleis" on 14/05/2023, 14:30 - 16:00 PM.
 
@@ -350,7 +350,7 @@ Example of a theater performance aimed at toddlers of 3-4 years old in "hetpalei
 }
 ```
 
-**guided tour**
+### Guided tour
 
 Example of a guided tour at the Royal Museum of Fine Arts Antwerp aimed at university and college students.
 
@@ -380,7 +380,7 @@ Example of a guided tour at the Royal Museum of Fine Arts Antwerp aimed at unive
 }
 ```
 
-**bookable event**
+### Bookable event
 
 Example of a bookable school event aimed at students of "derde graad BSO":
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -163,7 +163,7 @@ Subject labels are used to specify the learning objective of the school event.
 | Duurzaamheid, natuur en milieu              | `cultuurkuur_Duurzaamheid, natuur en milieu`              |
 | Filosofie religie                           | `cultuurkuur_Filosofie-religie`                           |
 | Internationale - Europese thema's           | `cultuurkuur_Internationale - Europese thema's`           |
-| kunst en cultuur                            | `cultuurkuur_kunst-en-cultuur`                            |
+| Kunst en cultuur                            | `cultuurkuur_kunst-en-cultuur`                            |
 | Leren leren                                 | `cultuurkuur_Leren leren`                                 |
 | Lichamelijke, sociale en mentale gezondheid | `cultuurkuur_Lichamelijke, sociale en mentale gezondheid` |
 | Media                                       | `cultuurkuur_Media`                                       |

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -25,11 +25,7 @@ The user or client that created the event will become the `creator` of the onlin
 
 ## Types
 
-We distinguish 3 different types of school events:
-
-1. **School performances** are events of which both the date and the location is known in advance.
-2. **Guided tours** are events that have no specific date, but they do have a location.
-3. **Bookable events** are events that have no specific date and location (or the date and location is not known in advance). Both the date and the location are determined in mutual agreement between the organizer or artist and the consumer (school).
+We distinguish 3 different types of school events.
 
 ### School performances
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -86,9 +86,9 @@ For the creation of school events several extra requirements apply:
 
 1. The `audienceType` must be set to `education`
 2. The event must have an `organizer` that has the `Cultuurkuur` label
-3. Specific education related `labels` are mandatory
-4. In case of a [guided tour](#guided-tours) or a [bookable event](#bookable-events): the `calendarType` must be set to `permanent`
-5. In case of a [bookable event](#bookable-events): the `location in consultation with the school` must be used for the location
+3. In case of a [guided tour](#guided-tours) or a [bookable event](#bookable-events): the `calendarType` must be set to `permanent`
+4. In case of a [bookable event](#bookable-events): the `location in consultation with the school` must be used for the location
+5. Every school event must have at least one label that indicates the education level of the target audience
 
 ### audienceType
 
@@ -126,6 +126,33 @@ Prefix this value with the host url of the according environment and use this as
 ```
 
 > Only in the case the organizer of your event does not already have its own page on Cultuurkuur yet, you can [create a new organizer on Cultuurkuur](https://www.cultuurkuur.be/faq/hoe-voeg-ik-mijn-organisatie-toe-op-cultuurkuur).
+
+### calendarType
+
+In case of a [guided tours](#guided-tours) or [bookable event](#bookable-events) you must set the value for the `calendarType` property to `permanent`.
+
+```json
+{
+  "calendarType": "permanent"
+}
+```
+
+### location in consultation with the school
+
+In case of a [bookable event](#bookable-events) you must use the url of the "location in consultation with the school" as the value for the `location.@id` property in the `POST /events` request of the event(s) that you want to create.
+
+**URLs**:
+
+* Test environment: `https://io-test.uitdatabank.be/place/3b92c85b-a923-4895-85f5-ed056dae11e2`
+* Production environment: `https://io.uitdatabank.be/place/c3f9278e-228b-4199-8f9a-b9716a17e58f`
+
+```json
+{
+"location": {
+    "@id": "https://io.uitdatabank.be/place/c3f9278e-228b-4199-8f9a-b9716a17e58f"
+  }
+}
+```
 
 ### labels
 
@@ -306,33 +333,6 @@ The following level 4 labels must always be combined with
 | Derde graad KSO                     | `cultuurkuur_derde-graad-KSO`                   |
 | Derde graad TSO                     | `cultuurkuur_derde-graad-TSO`                   |
 | Derde graad Voorbereidend jaar HO   | `cultuurkuur_derde-graad-Voorbereidend-jaar-HO` |
-
-### calendarType
-
-In case of a [guided tours](#guided-tours) or [bookable event](#bookable-events) you must set the value for the `calendarType` property to `permanent`.
-
-```json
-{
-  "calendarType": "permanent"
-}
-```
-
-### location in consultation with the school
-
-In case of a [bookable event](#bookable-events) you must use the url of the "location in consultation with the school" as the value for the `location.@id` property in the `POST /events` request of the event(s) that you want to create.
-
-**URLs**:
-
-* Test environment: `https://io-test.uitdatabank.be/place/3b92c85b-a923-4895-85f5-ed056dae11e2`
-* Production environment: `https://io.uitdatabank.be/place/c3f9278e-228b-4199-8f9a-b9716a17e58f`
-
-```json
-{
-"location": {
-    "@id": "https://io.uitdatabank.be/place/c3f9278e-228b-4199-8f9a-b9716a17e58f"
-  }
-}
-```
 
 ## Request body examples
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -57,7 +57,7 @@ Creating a school event is the same as [creating a regular event](./create.md), 
 1. The `audience.audienceType` property must be set to `education`
 2. The event must be linked to an `organizer` that has the `Cultuurkuur` label
 3. In case of a [guided tour](#guided-tours) or a [bookable event](#bookable-events), the `calendarType` must be set to `permanent`
-4. In case of a [bookable event](#bookable-events), the `location in consultation with the school` must be used for the location
+4. In case of a [bookable event](#bookable-events), the *"Location in consultation with the school"* place must be used for the location
 5. The event must have at least one label that indicates the education level of the target audience
 
 We will go over these required properties in more detail below, followed by some examples.

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -145,6 +145,7 @@ For school events, specific Cultuurkuur-related labels are mandatory. There are 
 Target group labels are used to specify whether the event is for students or for teachers.
 
 > A school event must have **exactly one** target group label.
+
 | Target group | Label                      |
 | :----------- | :------------------------- |
 | Students     | `cultuurkuur_Leerlingen`   |
@@ -155,6 +156,7 @@ Target group labels are used to specify whether the event is for students or for
 Subject labels are used to specify the learning objective of the school event.
 
 > A school event must have **at least one** subject label.
+
 | Subject                                     | Label                                                     |
 | :------------------------------------------ | :-------------------------------------------------------- |
 | Actief Burgerschap                          | `cultuurkuur_Actief Burgerschap`                          |

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -17,6 +17,8 @@ School events are events that are specifically organized and intended for:
 
 School events are published on [Cultuurkuur](https://www.cultuurkuur.be), but not on UiTinVlaanderen.
 
+Creating an online event is very similar to [creating a regular new event](./create.md), so it is recommended to read that guide first.
+
 > There is also a user interface available to enter school events, on <https://www.uitdatabank.be>. We recommend using this interface if you only organize a limited number of school events per year.
 >
 > For questions about school events, please contact <content.cultuurkuur@publiq.be>.

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -129,49 +129,9 @@ Prefix this value with the host url of the according environment and use this as
 
 ### labels
 
-For school events, specific Cultuurkuur-related labels are mandatory. There are 3 different types of Cultuurkuur-related labels:
-
-1. **Target group labels** are used to specify whether the event is for students or for teachers.
-2. **Subject labels** are used to define the learning objective of the school event.
-3. **Education level labels** indicate to which education levels (grades) the school event is aimed at.
-
-#### Target group labels
-
-Target group labels are used to specify whether the event is for students or for teachers.
-
-> A school event must have **exactly one** target group label.
-
-| Target group | Label                      |
-| :----------- | :------------------------- |
-| Students     | `cultuurkuur_Leerlingen`   |
-| Teachers     | `cultuurkuur_leerkrachten` |
-
-#### Subject labels
-
-Subject labels are used to specify the learning objective of the school event.
-
-> A school event must have **at least one** subject label.
-
-| Subject                                     | Label                                                     |
-| :------------------------------------------ | :-------------------------------------------------------- |
-| Actief Burgerschap                          | `cultuurkuur_Actief Burgerschap`                          |
-| Duurzaamheid, natuur en milieu              | `cultuurkuur_Duurzaamheid, natuur en milieu`              |
-| Filosofie religie                           | `cultuurkuur_Filosofie-religie`                           |
-| Internationale - Europese thema's           | `cultuurkuur_Internationale - Europese thema's`           |
-| kunst en cultuur                            | `cultuurkuur_kunst-en-cultuur`                            |
-| Leren leren                                 | `cultuurkuur_Leren leren`                                 |
-| Lichamelijke, sociale en mentale gezondheid | `cultuurkuur_Lichamelijke, sociale en mentale gezondheid` |
-| Media                                       | `cultuurkuur_Media`                                       |
-| Mobiliteit                                  | `cultuurkuur_Mobiliteit`                                  |
-| Ondernemingszin                             | `cultuurkuur_Ondernemingszin`                             |
-| Taal                                        | `cultuurkuur_taal`                                        |
-| Wiskunde                                    | `cultuurkuur_Wiskunde`                                    |
-
-#### Education level labels
+Each school event must have **at least one** education level label.
 
 Education level labels indicate to which education levels (grades) the school event is aimed at.
-
-> A school event must have **at least one** education level label.
 
 There is a hierarchical relationship between the different education level labels, and this hierarchy must be followed.
 
@@ -180,7 +140,7 @@ There is a hierarchical relationship between the different education level label
 * If a level 4 label (e.g. `cultuurkuur_Kleuter-2-3-jaar`) is applicable on an event, the corresponding level 3, level 2 and level 1 label must also be added to the event: `cultuurkuur_Gewoon-kleuteronderwijs` (level 3), `cultuurkuur_Gewoon-basisonderwijs` (level 2) and `cultuurkuur_basisonderwijs` (level 1)
 * If only level 1 label is applicable (e.g. `cultuurkuur_Volwassenenonderwijs`), then it suffices to add only the level 1 label
 
-##### Level 1 labels
+#### Level 1 labels
 
 | Education level          | Label (level 1)                            |
 | :----------------------- | :----------------------------------------- |
@@ -190,7 +150,7 @@ There is a hierarchical relationship between the different education level label
 | Volwassenenonderwijs     | `cultuurkuur_Volwassenenonderwijs`         |
 | Deeltijds kunstonderwijs | `cultuurkuur_Deeltijds-kunstonderwijs-DKO` |
 
-##### Level 2 labels
+#### Level 2 labels
 
 > A level 2 label must always be combined with a level 1 label.
 
@@ -224,7 +184,7 @@ The following labels must always be combined with level 1 label `cultuurkuur_Dee
 | Muziek                          | `cultuurkuur_muziek`                          |
 | Woordkunst & drama              | `cultuurkuur_Woordkunst-drama`                |
 
-##### Level 3 labels
+#### Level 3 labels
 
 > A level 3 label must always be combined with both a level 1 label and a level 2 label.
 
@@ -268,7 +228,7 @@ The following level 3 labels must always be combined with:
 | Secundair na Secundair (Se-n-Se)                      | `cultuurkuur_Secundair-na-secundair-(Se-n-Se)`                    |
 | Onthaalonderwijs voor anderstalige nieuwkomers (OKAN) | `cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers-OKAN` |
 
-##### Level 4 labels
+#### Level 4 labels
 
 > A level 4 label must always be combined with both a level 1, level 2 and level 3 label.
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -310,7 +310,7 @@ The following level 4 labels must always be combined with
 
 ### School performance
 
-Example of a theater performance aimed at toddlers of 3-4 years old in "hetpaleis" on 14/05/2023, 14:30 - 16:00 PM.
+Example of a theater performance aimed at toddlers of 3-4 years old in "hetpaleis" on 14/05/2023, from 14:30 to 16:00.
 
 ```json
 {

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -109,7 +109,7 @@ In case of a [guided tours](#guided-tours) or [bookable event](#bookable-events)
 }
 ```
 
-[School performances](#school-performances) should set the `calendarType` property to `single`, `multiple` or `periodic` depending on the schedule of the performance.
+In case of [school performances](#school-performances), you must set the `calendarType` property to `single`, `multiple` or `periodic` depending on the schedule of the performance.
 
 See the [guide about calendar info](../shared/calendar-info.md) for more details.
 

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -382,7 +382,7 @@ Example of a guided tour at the Royal Museum of Fine Arts Antwerp aimed at unive
 
 ### Bookable event
 
-Example of a bookable school event aimed at students of "derde graad BSO":
+Example of a bookable school event aimed at students of "derde graad BSO". Note that the location points to the *"Locatie in overleg met de school"* place on the test environment in this case.
 
 ```json
 {

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -68,7 +68,7 @@ For school events you must include an extra property `audienceType` and set the 
 
 ```json
 {
-"audience": {
+  "audience": {
     "audienceType": "education"
   }
 }
@@ -120,7 +120,7 @@ In case of a [bookable event](#bookable-events) you must use the url of the "loc
 
 ```json
 {
-"location": {
+  "location": {
     "@id": "https://io.uitdatabank.be/place/c3f9278e-228b-4199-8f9a-b9716a17e58f"
   }
 }

--- a/projects/uitdatabank/docs/entry-api/events/create-school.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-school.md
@@ -29,7 +29,7 @@ We distinguish 3 different types of school events.
 
 ### School performances
 
-School performances are events of which both the date and the location is known in advance. For example, a theater performance aimed at a toddler of 3-4 years old in "hetpaleis" on 14/05/2023, 14:30 - 16:00 PM.
+School performances are events of which both the date and the location is known in advance. For example, a theater performance aimed at a toddler of 3-4 years old in "hetpaleis" on 14/05/2023, from 14:30 to 16:00.
 
 * ✅ date is known in advance
 * ✅ location is known in advance

--- a/projects/uitdatabank/docs/entry-api/events/create-uitpas.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-uitpas.md
@@ -25,7 +25,7 @@ Before diving in, make sure you have read the following guides first:
 
 As with regular events, anyone can create new UiTPAS events in UiTdatabank by using either a user access token or a client access token.
 
-The user or client that created the event will become the `creator` of the online event, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
+The user or client that created the event will become its `creator`, which allows them to later make changes to it or delete it. In some cases other users or clients may also be able to edit the event afterward. See the permissions info in the guide about [updating an event](./update.md) for more info.
 
 ## Creating an UiTPAS event
 


### PR DESCRIPTION
### Changed

- Minor changes to the school events guide, like adding a link to the guide about creating new events to read that first, adding some info about permissions, and some other minor additions/tweaks.

### Removed

- Obsolete "target group" and "subject" labels

### Fixed

- Fixed very small typo in the UiTPAS events guide and copied the new wording to the school events & online events guides

---

Ticket: https://jira.uitdatabank.be/browse/III-5108
