### PR TITLE
III-5108 Remove "copying an event" page

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/copy.md
+++ b/projects/uitdatabank/docs/entry-api/events/copy.md
@@ -1,8 +1,0 @@
-Coming soon.
-
-<!-- 
-  @todo 
-  Explain how to copy an existing event.
-  Mention that the copy will not be kept in sync with the original.
-  Permissions: Who can make a copy?
--->

--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -92,12 +92,6 @@
             },
             {
               "type": "item",
-              "title": "Copying an existing event",
-              "uri": "/docs/entry-api/events/copy.md",
-              "slug": "entry-api/events/copying-an-existing-event"
-            },
-            {
-              "type": "item",
               "title": "Updating an event",
               "uri": "/docs/entry-api/events/update.md",
               "slug": "entry-api/events/updating-an-event"


### PR DESCRIPTION
### Removed

- Removed "Copying an existing event" page, because the relevant endpoint is marked as internal

---

Ticket: https://jira.uitdatabank.be/browse/III-5108
