### PR TITLE
III-5108 Replace absolute URLs to OpenAPI endpoints with relative ones

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/create-online.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-online.md
@@ -221,8 +221,8 @@ Keep the following restrictions in mind:
 * When changing the attendanceMode from `online` **to** `offline` or `mixed`, you must add a `location` property with an `@id` that links to the place where the event happens at.
 * When changing the attendanceMode from `online` or `mixed` **to** `offline`, the `onlineUrl` property will be removed from the event if present.
 
-You can also update the `attendanceMode` and/or `onlineUrl` of an event using the following endpoints if you do not want to use the [`PUT /events/{eventId}`](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/update-a-event) endpoint to update the event completely:
+You can also update the `attendanceMode` and/or `onlineUrl` of an event using the following endpoints if you do not want to use the [`PUT /events/{eventId}`](/reference/entry.json/paths/~1events~1{eventId}/put) endpoint to update the event completely:
 
-* [`PUT /events/{eventId}/attendance-mode`](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/update-a-event-attendance-mode)
-* [`PUT /events/{eventId}/online-url`](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/update-a-event-online-url)
-* [`DELETE /events/{eventId}/online-url`](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/delete-a-event-online-url)
+* [`PUT /events/{eventId}/attendance-mode`](reference/entry.json/paths/~1events~1{eventId}~1attendance-mode/put)
+* [`PUT /events/{eventId}/online-url`](/reference/entry.json/paths/~1events~1{eventId}~1online-url/put)
+* [`DELETE /events/{eventId}/online-url`](/reference/entry.json/paths/~1events~1{eventId}~1online-url/delete)

--- a/projects/uitdatabank/docs/entry-api/events/create-online.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-online.md
@@ -223,6 +223,6 @@ Keep the following restrictions in mind:
 
 You can also update the `attendanceMode` and/or `onlineUrl` of an event using the following endpoints if you do not want to use the [`PUT /events/{eventId}`](/reference/entry.json/paths/~1events~1{eventId}/put) endpoint to update the event completely:
 
-* [`PUT /events/{eventId}/attendance-mode`](reference/entry.json/paths/~1events~1{eventId}~1attendance-mode/put)
+* [`PUT /events/{eventId}/attendance-mode`](/reference/entry.json/paths/~1events~1{eventId}~1attendance-mode/put)
 * [`PUT /events/{eventId}/online-url`](/reference/entry.json/paths/~1events~1{eventId}~1online-url/put)
 * [`DELETE /events/{eventId}/online-url`](/reference/entry.json/paths/~1events~1{eventId}~1online-url/delete)

--- a/projects/uitdatabank/docs/entry-api/events/create-uitpas.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-uitpas.md
@@ -171,7 +171,7 @@ When the event is registered successfully, UiTPAS will automatically add the cor
 
 ## Getting UiTPAS prices for an event in UiTdatabank
 
-While UiTPAS automatically calculates and stores the discounted UiTPAS prices for an event, they are currently not returned by default when [fetching the event details from UiTdatabank](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/get-a-event).
+While UiTPAS automatically calculates and stores the discounted UiTPAS prices for an event, they are currently not returned by default when [fetching the event details from UiTdatabank](/reference/entry.json/paths/~1events~1{eventId}/get).
 
 To include the UiTPAS prices of an event when fetching it, you must add an `embedUitpasPrices` query parameter to the URL and set it to `true`.
 
@@ -268,7 +268,7 @@ For example:
 }
 ```
 
-You may set this property when creating the event, or when [updating](./update.md) it later. You can also set it via the [`PUT /events/{eventId}/audience`](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/update-a-event-audience) endpoint.
+You may set this property when creating the event, or when [updating](./update.md) it later. You can also set it via the [`PUT /events/{eventId}/audience`](/reference/entry.json/paths/~1events~1{eventId}~1audience/put) endpoint.
 
 ## More info
 

--- a/projects/uitdatabank/docs/entry-api/events/create.md
+++ b/projects/uitdatabank/docs/entry-api/events/create.md
@@ -21,7 +21,7 @@ The user or client that created the event will become the `creator` of the event
 
 ## Overview
 
-You can create a new event by making a single HTTP request to the [`POST /events`](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/create-a-event) endpoint. If successful, the event will be created and the response will contain the event's id and URL which you can store to make changes to the event later.
+You can create a new event by making a single HTTP request to the [`POST /events`](/reference/entry.json/paths/~1events/post) endpoint. If successful, the event will be created and the response will contain the event's id and URL which you can store to make changes to the event later.
 
 A request to create a new event for a music concert happening on a single evening in the Ancienne Belgique, with only the required fields, looks like this:
 
@@ -125,7 +125,7 @@ Let's take a closer look at the properties of an event.
 
 ## Required properties
 
-Every event has a couple of properties that are required to create it, and that are always guaranteed to be on existing events. A summary of every required property is provided below, but you can find more details in the [complete event model](../../../models/event-with-read-example.json) and [`POST /events`](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/create-a-event) endpoint documentation.
+Every event has a couple of properties that are required to create it, and that are always guaranteed to be on existing events. A summary of every required property is provided below, but you can find more details in the [complete event model](../../../models/event-with-read-example.json) and [`POST /events`](/reference/entry.json/paths/~1events/post) endpoint documentation.
 
 ### mainLanguage
 
@@ -192,7 +192,7 @@ Example for an event happening at the Ancienne Belgique (id `787d7420-c06f-4935-
 }
 ```
 
-After creating the event, the rest of the place's data will be embedded automatically in the `location` property when you [fetch the event](https://docs.publiq.be/docs/uitdatabank/entry-api/reference/operations/get-a-event) from UiTdatabank. That way you don't need to fetch the place separately when you want to display the event with its location data (like the address) somewhere.
+After creating the event, the rest of the place's data will be embedded automatically in the `location` property when you [fetch the event](/reference/entry.json/paths/~1events~1{eventId}/get) from UiTdatabank. That way you don't need to fetch the place separately when you want to display the event with its location data (like the address) somewhere.
 
 To find the right place URI to use as `@id`, read our guide about [finding and reusing existing places](../places/finding-and-reusing-places.md). If the place that you need does not exist yet in UiTdatabank, you may also [create a new place](../places/create.md).
 
@@ -200,7 +200,7 @@ To find the right place URI to use as `@id`, read our guide about [finding and r
 
 This property contains a list of [taxonomy terms](../../taxonomy-api/terms.md) that categorize the event in one of various types and optionally a theme. Specific partners may also add accessibility facilities as terms.
 
-The possible taxonomy terms can be browsed via the [`GET /terms`](https://docs.publiq.be/docs/uitdatabank/taxonomy-api/reference/operations/list-terms) endpoint on the Taxonomy API.
+The possible taxonomy terms can be browsed via the [`GET /terms`](/reference/taxonomy.json/paths/~1terms/get) endpoint on the Taxonomy API.
 
 To create an event, at least one term of the domain `eventtype` and a `scope` that contains `events` is required. For example the following term that categorizes an event as a concert:
 

--- a/projects/uitdatabank/docs/search-api/getting-started.md
+++ b/projects/uitdatabank/docs/search-api/getting-started.md
@@ -27,13 +27,13 @@ Search API v3 can be reached at two URLs:
 
 Search API consists of three endpoints to query events and/or places:
 
-* [`GET /events`](https://docs.publiq.be/docs/uitdatabank/search-api/reference/operations/list-events) to query events
-* [`GET /places`](https://docs.publiq.be/docs/uitdatabank/search-api/reference/operations/list-places) to query places
-* [`GET /offers`](https://docs.publiq.be/docs/uitdatabank/search-api/reference/operations/list-offers) to query both events and places at the same time
+* [`GET /events`](/reference/search.json/paths/~1events/get) to query events
+* [`GET /places`](/reference/search.json/paths/~1places/get) to query places
+* [`GET /offers`](/reference/search.json/paths/~1offers/get) to query both events and places at the same time
 
 These three endpoints all support the same URL parameters to perform queries and/or filters.
 
-Additionally, Search API also has a [`GET /organizers`](https://docs.publiq.be/docs/uitdatabank/search-api/reference/operations/list-organizers) endpoint to query organizers. This endpoint supports different URL parameters than the ones for events and places, because organizers do not share the exact same properties as events and places.
+Additionally, Search API also has a [`GET /organizers`](/reference/search.json/paths/~1organizers/get) endpoint to query organizers. This endpoint supports different URL parameters than the ones for events and places, because organizers do not share the exact same properties as events and places.
 
 ## Your first request
 


### PR DESCRIPTION
### Changed

- Changed absolute URLs to endpoints in OpenAPI files with relative ones. Stoplight will automatically "prettify" these like links to `.md` files.

---

Ticket: https://jira.uitdatabank.be/browse/III-5108

Note: There is actually an issue with these links, because links that start with `/` are not checked by the dead link checker for some reason. But also, in theory this is not a valid path because everything after the `.json` does not exist on the file system, so the dead linker checker would complain about them. So in this case it's useful, but should be improved to actually check that the link works. I've created a  ticket for that: https://jira.uitdatabank.be/browse/API-116
In the meantime I've replaced the links to this format because other docs like UiTPAS also do it like this. So then it's uniform already.
