### PR TITLE
Fix a syntax error on the create reward page, typo and stats

### DIFF
--- a/projects/uitpas/docs/creating-rewards.md
+++ b/projects/uitpas/docs/creating-rewards.md
@@ -55,9 +55,9 @@ Authorization: Bearer YOUR_ACCESS_TOKEN'
 
 {
  "organizers": {
-    {
+    [
       "id": "0ce87cbc-9299-4528-8d35-92225dc9489f"
-    }
+    ]
   },
   "title": "Gratis ticket Design Museum Brussels",
   "type": "POINTS",

--- a/projects/uitpas/docs/introduction.md
+++ b/projects/uitpas/docs/introduction.md
@@ -4,7 +4,7 @@
 
 ## What is UiTPAS?
 
-UiTPAS is a loyalty card for cultural, sports, and pastime events in Flanders and Brussels. More than 250.000 passholders can save points by attending events and trade them for rewards.
+UiTPAS is a loyalty card for cultural, sports, and pastime events in Flanders and Brussels. More than 380.000 passholders can save points by attending events and trade them for rewards.
 
 Next to rewards, passholders in need can receive a social tariff ('kansentarief') on UiTPAS events. Those discounts are payed for via a third-party payer system in which the organizer of the event, the local government and the passholder each pay a percentage of the ticket price.
 
@@ -12,7 +12,7 @@ Next to rewards, passholders in need can receive a social tariff ('kansentarief'
 
 Check out our [development quick start guide](https://publiq.stoplight.io/docs/uitpas/docs/quickstart.md) to get up and running.
 
-The UiTAS API follows the [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) principles. Our APIs have predictable resource-oriented URLs, accept and return [JSON](https://www.json.org/json-en.html)-encoded data, and use standard HTTP methods, status codes and [authentication](./authentication.md)).
+The UiTPAS API follows the [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) principles. Our APIs have predictable resource-oriented URLs, accept and return [JSON](https://www.json.org/json-en.html)-encoded data, and use standard HTTP methods, status codes and [authentication](./authentication.md)).
 
 In our documentation you will find:
 


### PR DESCRIPTION
### Changed
3 small changes:
- Fix a syntax error on the create reward page
- Fix typo on "getting started" page
- Correct passholder stats (250.000 -> 380.000 passholders)

