### PR TITLE
UPS-4374 specify string type for new array params

### DIFF
--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -3557,7 +3557,10 @@
           },
           {
             "schema": {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "in": "query",
             "name": "organizerId",
@@ -3567,7 +3570,10 @@
           },
           {
             "schema": {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "in": "query",
             "name": "organizerPostalCode",
@@ -3577,7 +3583,10 @@
           },
           {
             "schema": {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "in": "query",
             "name": "owningCardSystemId",
@@ -3587,7 +3596,10 @@
           },
           {
             "schema": {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "in": "query",
             "name": "applicableCardSystemId",


### PR DESCRIPTION
### Fixed

- Java code generation tools expect explicit type for arrays

---

Ticket: https://jira.uitdatabank.be/browse/UPS-4374
