### PR TITLE
III-5428 update video url regex

### DIFF
--- a/projects/uitdatabank/models/common-string-uri-video.json
+++ b/projects/uitdatabank/models/common-string-uri-video.json
@@ -3,7 +3,7 @@
   "type": "string",
   "format": "uri",
   "description": "The unique url of the video. Currently only Youtube and Vimeo sources are allowed.",
-  "pattern": "^http(s?):\\/\\/(www\\.)?((youtube\\.com\\/watch\\?v=([^\\/#&?]*))|(vimeo\\.com\\/([^\\/#&?]*))|(youtu\\.be\\/([^\\/#&?]*))|(youtube.com\/embed\/([^\/#&?]*)))",
+  "pattern": "^http(s?):\\/\\/(www\\.)?((youtube\\.com\\/watch\\?v=([^\\/#&?]*))|(vimeo\\.com\\/([^\\/#&?]*))|(youtu\\.be\\/([^\\/#&?]*))|(youtube.com\/embed\/([^\\/#&?]*)))",
   "examples": [
     "https://www.youtube.com/watch?v=cEItmb_a20D"
   ]

--- a/projects/uitdatabank/models/common-string-uri-video.json
+++ b/projects/uitdatabank/models/common-string-uri-video.json
@@ -3,7 +3,7 @@
   "type": "string",
   "format": "uri",
   "description": "The unique url of the video. Currently only Youtube and Vimeo sources are allowed.",
-  "pattern": "^http(s?):\\/\\/(www\\.)?((youtube\\.com\\/watch\\?v=([^\\/#&?]*))|(vimeo\\.com\\/([^\\/#&?]*))|(youtu\\.be\\/([^\\/#&?]*)))",
+  "pattern": "^http(s?):\\/\\/(www\\.)?((youtube\\.com\\/watch\\?v=([^\\/#&?]*))|(vimeo\\.com\\/([^\\/#&?]*))|(youtu\\.be\\/([^\\/#&?]*))|(youtube.com\/embed\/([^\/#&?]*)))",
   "examples": [
     "https://www.youtube.com/watch?v=cEItmb_a20D"
   ]


### PR DESCRIPTION
### Changed

- Update `regex` for `video-urls` to allow embedded `YouTube`-url eg. `https://www.youtube.com/embed/yi_XlQetN28`

---

Ticket: https://jira.uitdatabank.be/browse/III-5428
