### PR TITLE
III-5581 update regex url to catch triple slashes

### DIFF
--- a/projects/uitdatabank/models/common-string-uri.json
+++ b/projects/uitdatabank/models/common-string-uri.json
@@ -3,7 +3,7 @@
   "description": "A URI with the HTTP or HTTPS protocol.",
   "type": "string",
   "format": "uri",
-  "pattern": "^http[s]?:\\/\\/",
+  "pattern": "^http[s]?:\\/\\/\\w",
   "examples": [
     "https://www.example.com"
   ]


### PR DESCRIPTION
### Changed

- Changed regex for `common-string-uri`

### Fixed

- Catch triple Slashed Uri's(e.g., `https:///publiq.be`)
---

Ticket: https://jira.uitdatabank.be/browse/III-5581
