### PR TITLE
Uitdatabank/III-5556 Get productions Json Corrections

### DIFF
--- a/projects/uitdatabank/models/production.json
+++ b/projects/uitdatabank/models/production.json
@@ -5,41 +5,37 @@
   "description": "A production that 2 or more events are part of",
   "examples": [
     {
-      "id": "c356dac7-133b-4847-805f-91a8c3c09da6",
-      "title": "Alex Agnew speelt 'Wake Me Up When It's Over'",
-      "otherEvents": [
-        "https://io.uitdatabank.be/event/4f37a230-8d8d-4dab-a527-62e879629bae",
-        "https://io.uitdatabank.be/event/7f32b131-deb9-483f-ab32-98541d3c3b77",
-        "https://io.uitdatabank.be/event/c41effec-0e04-4e01-8804-9ea9b4c6b528"
+      "production_id": "c356dac7-133b-4847-805f-91a8c3c09da6",
+      "name": "Alex Agnew speelt 'Wake Me Up When It's Over'",
+      "events": [
+        "4f37a230-8d8d-4dab-a527-62e879629bae",
+        "7f32b131-deb9-483f-ab32-98541d3c3b77",
+        "c41effec-0e04-4e01-8804-9ea9b4c6b528"
       ]
-    },
-    {
-      "id": "c356dac7-133b-4847-805f-91a8c3c09da6",
-      "title": "Alex Agnew speelt 'Wake Me Up When It's Over'"
     }
   ],
   "properties": {
-    "id": {
+    "production_id": {
       "$ref": "./common-string-uuid.json",
       "description": "The uuid of the production"
     },
-    "title": {
+    "name": {
       "type": "string",
       "description": "The title of the production",
       "example": "Alex Agnew speelt 'Wake Me Up When It's Over'"
     },
-    "otherEvents": {
+    "events": {
       "type": "array",
       "description": "List of events that are part of the production",
       "items": {
         "type": "string",
-        "format": "uri"
+        "format": "uuid"
       }
     }
   },
   "required": [
-    "id",
-    "title",
-    "otherEvents"
+    "production_id",
+    "name",
+    "events"
   ]
 }

--- a/projects/uitdatabank/models/production.json
+++ b/projects/uitdatabank/models/production.json
@@ -5,7 +5,7 @@
   "description": "A production that 2 or more events are part of",
   "examples": [
     {
-      "production_id": "c356dac7-133b-4847-805f-91a8c3c09da6",
+      "productionId": "c356dac7-133b-4847-805f-91a8c3c09da6",
       "name": "Alex Agnew speelt 'Wake Me Up When It's Over'",
       "events": [
         "4f37a230-8d8d-4dab-a527-62e879629bae",
@@ -15,7 +15,7 @@
     }
   ],
   "properties": {
-    "production_id": {
+    "productionId": {
       "$ref": "./common-string-uuid.json",
       "description": "The uuid of the production"
     },
@@ -28,13 +28,12 @@
       "type": "array",
       "description": "List of events that are part of the production",
       "items": {
-        "type": "string",
-        "format": "uuid"
+        "type": "string"
       }
     }
   },
   "required": [
-    "production_id",
+    "productionId",
     "name",
     "events"
   ]

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -8043,7 +8043,7 @@
                     "value": {
                       "hydra:member": [
                         {
-                          "production_id": "c356dac7-133b-4847-805f-91a8c3c09da6",
+                          "productionId": "c356dac7-133b-4847-805f-91a8c3c09da6",
                           "name": "Alex Agnew speelt 'Wake Me Up When It's Over'",
                           "events": [
                             "4f37a230-8d8d-4dab-a527-62e879629bae",
@@ -8067,7 +8067,7 @@
                   "Example 1": {
                     "value": [
                       {
-                        "production_id": "c356dac7-133b-4847-805f-91a8c3c09da6",
+                        "productionId": "c356dac7-133b-4847-805f-91a8c3c09da6",
                         "name": "Alex Agnew speelt 'Wake Me Up When It's Over'",
                         "events": [
                           "4f37a230-8d8d-4dab-a527-62e879629bae",

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -8043,12 +8043,12 @@
                     "value": {
                       "hydra:member": [
                         {
-                          "id": "c356dac7-133b-4847-805f-91a8c3c09da6",
-                          "title": "Alex Agnew speelt 'Wake Me Up When It's Over'",
-                          "otherEvents": [
-                            "https://io.uitdatabank.be/event/4f37a230-8d8d-4dab-a527-62e879629bae",
-                            "https://io.uitdatabank.be/event/7f32b131-deb9-483f-ab32-98541d3c3b77",
-                            "https://io.uitdatabank.be/event/c41effec-0e04-4e01-8804-9ea9b4c6b528"
+                          "production_id": "c356dac7-133b-4847-805f-91a8c3c09da6",
+                          "name": "Alex Agnew speelt 'Wake Me Up When It's Over'",
+                          "events": [
+                            "4f37a230-8d8d-4dab-a527-62e879629bae",
+                            "7f32b131-deb9-483f-ab32-98541d3c3b77",
+                            "c41effec-0e04-4e01-8804-9ea9b4c6b528"
                           ]
                         }
                       ]
@@ -8067,12 +8067,12 @@
                   "Example 1": {
                     "value": [
                       {
-                        "id": "c356dac7-133b-4847-805f-91a8c3c09da6",
-                        "title": "Alex Agnew speelt 'Wake Me Up When It's Over'",
-                        "otherEvents": [
-                          "https://io.uitdatabank.be/event/4f37a230-8d8d-4dab-a527-62e879629bae",
-                          "https://io.uitdatabank.be/event/7f32b131-deb9-483f-ab32-98541d3c3b77",
-                          "https://io.uitdatabank.be/event/c41effec-0e04-4e01-8804-9ea9b4c6b528"
+                        "production_id": "c356dac7-133b-4847-805f-91a8c3c09da6",
+                        "name": "Alex Agnew speelt 'Wake Me Up When It's Over'",
+                        "events": [
+                          "4f37a230-8d8d-4dab-a527-62e879629bae",
+                          "7f32b131-deb9-483f-ab32-98541d3c3b77",
+                          "c41effec-0e04-4e01-8804-9ea9b4c6b528"
                         ]
                       }
                     ]


### PR DESCRIPTION
### Changed

- Use correct `JsonBody` for `productions`

### Resolved:

- (Decide how to resolve camelCase vs. existing `production_id`)
- API uses both depracted snake_case `production_id` and camleCase `productionId`. Only `productionId` will be used in the docs.

---

Ticket: https://jira.uitdatabank.be/browse/III-5556
