### PR TITLE
UPS-4380 include redundant uitpas number in passholder

### DIFF
--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -548,6 +548,7 @@
                             },
                             "points": 10,
                             "uitidStatus": "UNREGISTERED",
+                            "uitpasNumber": "0930012345615",
                             "cardSystemMemberships": [
                               {
                                 "cardSystem": {
@@ -610,6 +611,7 @@
                             },
                             "points": 10,
                             "uitidStatus": "UNREGISTERED",
+                            "uitpasNumber": "0930012345615",
                             "cardSystemMemberships": [
                               {
                                 "cardSystem": {
@@ -1124,6 +1126,7 @@
                           },
                           "points": 10,
                           "uitidStatus": "UNREGISTERED",
+                          "uitpasNumber": "0930012345615",
                           "cardSystemMemberships": [
                             {
                               "cardSystem": {
@@ -1316,6 +1319,7 @@
                       },
                       "points": 10,
                       "uitidStatus": "UNREGISTERED",
+                      "uitpasNumber": "0930012345615",                      
                       "cardSystemMemberships": [
                         {
                           "cardSystem": {
@@ -2128,6 +2132,7 @@
                       },
                       "points": 10,
                       "uitidStatus": "UNREGISTERED",
+                      "uitpasNumber": "0930012345615",
                       "cardSystemMemberships": [
                         {
                           "cardSystem": {
@@ -2215,6 +2220,7 @@
                       "name": "Lastname",
                       "firstName": "Firstname",
                       "inszNumber": "19800101003",
+                      "uitpasNumber": "0999100000002",
                       "cardSystemMemberships": [
                         {
                           "cardSystem": {
@@ -5178,6 +5184,7 @@
           },
           "points": 10,
           "uitidStatus": "UNREGISTERED",
+          "uitpasNumber": "0930012345615",
           "cardSystemMemberships": [
             {
               "cardSystem": {
@@ -5230,6 +5237,10 @@
           "inszNumber": {
             "type": "string",
             "description": "Unique national (Belgian) INSZ number of an individual passholder to look up."
+          },
+          "uitpasNumber": {
+            "type": "string",
+            "description": "The UiTPAS number of this passholder. This field contains the UiTPAS number of the oldest, still active cardsystem membership, that has an active card."
           },
           "cardSystemMemberships": {
             "type": "array",


### PR DESCRIPTION
### Added

- include redundant uitpas number in passholder

---

Ticket: https://jira.uitdatabank.be/browse/UPS-4380
