### PR TITLE
III-5712 allow hashes in uri regex

### DIFF
--- a/projects/uitdatabank/models/common-string-uri.json
+++ b/projects/uitdatabank/models/common-string-uri.json
@@ -3,7 +3,7 @@
   "description": "A URI with the HTTP or HTTPS protocol.",
   "type": "string",
   "format": "uri",
-  "pattern": "^http[s]?:\\/\\/\\w",
+  "pattern": "^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
   "examples": [
     "https://www.example.com"
   ]

--- a/projects/uitdatabank/models/common-string-uri.json
+++ b/projects/uitdatabank/models/common-string-uri.json
@@ -3,7 +3,7 @@
   "description": "A URI with the HTTP or HTTPS protocol.",
   "type": "string",
   "format": "uri",
-  "pattern": "^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?(#.*)?$",
+  "pattern": "^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
   "examples": [
     "https://www.example.com"
   ]

--- a/projects/uitdatabank/models/common-string-uri.json
+++ b/projects/uitdatabank/models/common-string-uri.json
@@ -3,7 +3,7 @@
   "description": "A URI with the HTTP or HTTPS protocol.",
   "type": "string",
   "format": "uri",
-  "pattern": "^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
+  "pattern": "^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?(#.*)?$",
   "examples": [
     "https://www.example.com"
   ]


### PR DESCRIPTION
### Changed

- `common-string-uri.json`: updated regex

### Fixed

- Url's with `#` are now allowed

---

Ticket: https://jira.uitdatabank.be/browse/III-5712
