### PR TITLE
uitdatabank/Hotfix allow non https links

### DIFF
--- a/projects/uitdatabank/models/common-string-uri.json
+++ b/projects/uitdatabank/models/common-string-uri.json
@@ -3,7 +3,7 @@
   "description": "A URI with the HTTP or HTTPS protocol.",
   "type": "string",
   "format": "uri",
-  "pattern": "^https?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
+  "pattern": "^http[s]?:\\/\\/[\\w\\-\\.]+\\.\\w{2,}(\\/.*)?$",
   "examples": [
     "https://www.example.com"
   ]


### PR DESCRIPTION

### Fixed

- Allow `http` links for uri's.

---
