### PR TITLE
III-5822 use correct method name for merging productions

### DIFF
--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -8368,7 +8368,7 @@
           "$ref": "#/components/parameters/productionId2"
         }
       ],
-      "put": {
+      "post": {
         "summary": "productions - merge",
         "operationId": "productions-merge",
         "responses": {


### PR DESCRIPTION
### Fixed

- Use `POST` instead `PUT` for merging `productions`

---

Ticket: https://jira.uitdatabank.be/browse/III-5822