### PR TITLE
Projects: Ignore api Links

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -26,7 +26,8 @@
             "https://www.uitinhasselt.be",
             "https://github.com/cultuurnet/udb3-acceptance-tests",
             "https://github.com/cultuurnet/apidocs/settings/secrets/actions",
-            "https://www.uitinvlaanderen.be/agenda/e/horta-van-de-velde-de-trein-der-ontwerpers/ffe4f207-2f8d-4dce-87a6-08abf59aefbe"
+            "https://www.uitinvlaanderen.be/agenda/e/horta-van-de-velde-de-trein-der-ontwerpers/ffe4f207-2f8d-4dce-87a6-08abf59aefbe",
+            "https://api.publiq.be"
         ]
     },
     "remark-validate-links": null,


### PR DESCRIPTION
### Changed

- Added `api.publiq.be` to links to ignore, because it is a redirect and used in API responses.

### Fixed

- Linting is `green` again

---