### PR TITLE
Add security section for Search API requests

### DIFF
--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -291,7 +291,18 @@
           }
         ]
       },
-      "parameters": []
+      "parameters": [],
+            "security":[
+        {
+          "CLIENT_IDENTIFICATION":[]
+        },
+        {
+          "CLIENT_ACCESS_TOKEN":[]
+        },
+        {
+          "USER_ACCESS_TOKEN":[]
+        }
+        ]
     },
     "/offers": {
       "get": {
@@ -573,7 +584,18 @@
           }
         ]
       },
-      "parameters": []
+      "parameters": [],
+            "security":[
+        {
+          "CLIENT_IDENTIFICATION":[]
+        },
+        {
+          "CLIENT_ACCESS_TOKEN":[]
+        },
+        {
+          "USER_ACCESS_TOKEN":[]
+        }
+        ]
     },
     "/organizers": {
       "get": {
@@ -731,7 +753,18 @@
           }
         ]
       },
-      "parameters": []
+      "parameters": [],
+      "security":[
+        {
+          "CLIENT_IDENTIFICATION":[]
+        },
+        {
+          "CLIENT_ACCESS_TOKEN":[]
+        },
+        {
+          "USER_ACCESS_TOKEN":[]
+        }
+        ]
     },
     "/places": {
       "get": {
@@ -1003,7 +1036,18 @@
           }
         ]
       },
-      "parameters": []
+      "parameters": [],
+            "security":[
+        {
+          "CLIENT_IDENTIFICATION":[]
+        },
+        {
+          "CLIENT_ACCESS_TOKEN":[]
+        },
+        {
+          "USER_ACCESS_TOKEN":[]
+        }
+        ]
     }
   },
   "tags": [

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -302,8 +302,7 @@
         {
           "USER_ACCESS_TOKEN":[]
         }
-        ]
-    },
+        ],
     "/offers": {
       "get": {
         "summary": "Search events & places (offers)",
@@ -595,8 +594,7 @@
         {
           "USER_ACCESS_TOKEN":[]
         }
-        ]
-    },
+        ],
     "/organizers": {
       "get": {
         "summary": "Search organizers",
@@ -764,8 +762,7 @@
         {
           "USER_ACCESS_TOKEN":[]
         }
-        ]
-    },
+        ],
     "/places": {
       "get": {
         "summary": "Search places",
@@ -1037,17 +1034,6 @@
         ]
       },
       "parameters": [],
-            "security":[
-        {
-          "CLIENT_IDENTIFICATION":[]
-        },
-        {
-          "CLIENT_ACCESS_TOKEN":[]
-        },
-        {
-          "USER_ACCESS_TOKEN":[]
-        }
-        ]
     }
   },
   "tags": [

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -1,1841 +1,1855 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "Search API",
-    "version": "3.0",
-    "description": "With UiTdatabank's Search API you can search events, places and organizers.",
-    "contact": {
-      "name": "publiq helpdesk",
-      "email": "technical-support@publiq.be",
-      "url": "https://docs.publiq.be"
-    }
-  },
-  "servers": [
-    {
-      "url": "https://search-test.uitdatabank.be",
-      "description": "Testing"
-    },
-    {
-      "description": "Production",
-      "url": "https://search.uitdatabank.be"
-    }
-  ],
-  "paths": {
-    "/events": {
-      "get": {
-        "summary": "Search events",
-        "tags": [
-          "Events & places"
-        ],
-        "responses": {
-          "200": {
-            "description": "A single page of search results. If `?embed=true` is used, the search results will contain the complete JSON details. Otherwise only `@id` and `@type` will be returned.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "itemsPerPage": {
-                      "type": "integer",
-                      "example": 30,
-                      "description": "The amount of results that is being returned per page."
-                    },
-                    "totalItems": {
-                      "type": "integer",
-                      "example": 2345,
-                      "description": "Total amount of results for the given query parameters."
-                    },
-                    "member": {
-                      "type": "array",
-                      "description": "Search results (paginated). Note that the complete search results details will only be returned if `?embed=true` is used. Otherwise only the `@id` will be returned.",
-                      "items": {
-                        "$ref": "../models/event.json"
-                      }
-                    },
-                    "facet": {
-                      "type": "object",
-                      "description": "Facet counts per possible filter & value.",
-                      "properties": {
-                        "regions": {
-                          "$ref": "../models/common-facets.json"
-                        },
-                        "types": {
-                          "$ref": "../models/common-facets.json"
-                        },
-                        "themes": {
-                          "$ref": "../models/common-facets.json"
-                        },
-                        "facilities": {
-                          "$ref": "../models/common-facets.json"
-                        },
-                        "labels": {
-                          "$ref": "../models/common-facets.json"
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "itemsPerPage",
-                    "totalItems",
-                    "member"
-                  ]
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "itemsPerPage": 20,
-                      "totalItems": 3,
-                      "member": [
-                        {
-                          "@id": "https://io-test.uitdatabank.be/event/7dc08012-488b-4e2b-b318-625d9bce03d7",
-                          "@type": "Event"
-                        },
-                        {
-                          "@id": "https://io-test.uitdatabank.be/event/c683ddfe-4ff9-4b4b-a198-b9f553cfc479",
-                          "@type": "Event"
-                        },
-                        {
-                          "@id": "https://io-test.uitdatabank.be/event/15d5de07-57e6-4015-84c6-e9c94ccfd9ef",
-                          "@type": "Event"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        },
-        "operationId": "get-events",
-        "description": "Returns a paginated list of events that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.\n\nAdd `embedCalendarSummaries` to have an extra property `calendarSummary` in the results that contains one or more formatted human-readable summaries of the date/time info of the result. See <a href=\"search-api/calendar-summaries\">the guide about embedding the calendar summaries</a> for more details.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/x-client-id"
-          },
-          {
-            "$ref": "#/components/parameters/x-api-key"
-          },
-          {
-            "$ref": "#/components/parameters/text"
-          },
-          {
-            "$ref": "#/components/parameters/q"
-          },
-          {
-            "$ref": "#/components/parameters/postalCode"
-          },
-          {
-            "$ref": "#/components/parameters/addressCountry"
-          },
-          {
-            "$ref": "#/components/parameters/maxAge"
-          },
-          {
-            "$ref": "#/components/parameters/minAge"
-          },
-          {
-            "$ref": "#/components/parameters/allAges"
-          },
-          {
-            "$ref": "#/components/parameters/audienceType"
-          },
-          {
-            "$ref": "#/components/parameters/availableFrom"
-          },
-          {
-            "$ref": "#/components/parameters/availableTo"
-          },
-          {
-            "$ref": "#/components/parameters/attendanceMode"
-          },
-          {
-            "$ref": "#/components/parameters/bookingAvailability"
-          },
-          {
-            "$ref": "#/components/parameters/calendarType"
-          },
-          {
-            "$ref": "#/components/parameters/createdFrom"
-          },
-          {
-            "$ref": "#/components/parameters/createdTo"
-          },
-          {
-            "$ref": "#/components/parameters/modifiedFrom"
-          },
-          {
-            "$ref": "#/components/parameters/modifiedTo"
-          },
-          {
-            "$ref": "#/components/parameters/contributors"
-          },
-          {
-            "$ref": "#/components/parameters/creator"
-          },
-          {
-            "$ref": "#/components/parameters/dateFrom"
-          },
-          {
-            "$ref": "#/components/parameters/dateTo"
-          },
-          {
-            "$ref": "#/components/parameters/localTimeFrom"
-          },
-          {
-            "$ref": "#/components/parameters/localTimeTo"
-          },
-          {
-            "$ref": "#/components/parameters/embed"
-          },
-          {
-            "$ref": "#/components/parameters/embedCalendarSummaries"
-          },
-          {
-            "$ref": "#/components/parameters/embedUitpasPrices"
-          },
-          {
-            "$ref": "#/components/parameters/facets"
-          },
-          {
-            "$ref": "#/components/parameters/groupBy"
-          },
-          {
-            "$ref": "#/components/parameters/regions"
-          },
-          {
-            "$ref": "#/components/parameters/coordinates"
-          },
-          {
-            "$ref": "#/components/parameters/distance"
-          },
-          {
-            "$ref": "#/components/parameters/bounds"
-          },
-          {
-            "$ref": "#/components/parameters/id"
-          },
-          {
-            "$ref": "#/components/parameters/locationId"
-          },
-          {
-            "$ref": "#/components/parameters/organizerId"
-          },
-          {
-            "$ref": "#/components/parameters/labels"
-          },
-          {
-            "$ref": "#/components/parameters/locationLabels"
-          },
-          {
-            "$ref": "#/components/parameters/organizerLabels"
-          },
-          {
-            "$ref": "#/components/parameters/mainLanguage"
-          },
-          {
-            "$ref": "#/components/parameters/languages"
-          },
-          {
-            "$ref": "#/components/parameters/completedLanguages"
-          },
-          {
-            "$ref": "#/components/parameters/hasMediaObjects"
-          },
-          {
-            "$ref": "#/components/parameters/price"
-          },
-          {
-            "$ref": "#/components/parameters/minPrice"
-          },
-          {
-            "$ref": "#/components/parameters/maxPrice"
-          },
-          {
-            "$ref": "#/components/parameters/sortScore"
-          },
-          {
-            "$ref": "#/components/parameters/sortAvailableTo"
-          },
-          {
-            "$ref": "#/components/parameters/sortCreated"
-          },
-          {
-            "$ref": "#/components/parameters/sortModified"
-          },
-          {
-            "$ref": "#/components/parameters/sortDistance"
-          },
-          {
-            "$ref": "#/components/parameters/status"
-          },
-          {
-            "$ref": "#/components/parameters/termIds"
-          },
-          {
-            "$ref": "#/components/parameters/uitpas"
-          },
-          {
-            "$ref": "#/components/parameters/hasVideos"
-          },
-          {
-            "$ref": "#/components/parameters/workflowStatusOffer"
-          }
-        ]
-      },
-      "parameters": [],
-            "security":[
-        {
-          "CLIENT_IDENTIFICATION":[]
-        },
-        {
-          "CLIENT_ACCESS_TOKEN":[]
-        },
-        {
-          "USER_ACCESS_TOKEN":[]
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Search API",
+        "version": "3.0",
+        "description": "With UiTdatabank's Search API you can search events, places and organizers.",
+        "contact": {
+            "name": "publiq helpdesk",
+            "email": "technical-support@publiq.be",
+            "url": "https://docs.publiq.be"
         }
-        ],
-    "/offers": {
-      "get": {
-        "summary": "Search events & places (offers)",
-        "tags": [
-          "Events & places"
-        ],
-        "responses": {
-          "200": {
-            "description": "A single page of search results. If `?embed=true` is used, the search results will contain the complete JSON details. Otherwise only `@id` and `@type` will be returned.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "itemsPerPage": {
-                      "type": "integer",
-                      "example": 30,
-                      "description": "The amount of results that is being returned per page."
+    },
+    "servers": [
+        {
+            "url": "https://search-test.uitdatabank.be",
+            "description": "Testing"
+        },
+        {
+            "description": "Production",
+            "url": "https://search.uitdatabank.be"
+        }
+    ],
+    "paths": {
+        "/events": {
+            "get": {
+                "summary": "Search events",
+                "tags": [
+                    "Events & places"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A single page of search results. If `?embed=true` is used, the search results will contain the complete JSON details. Otherwise only `@id` and `@type` will be returned.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "itemsPerPage": {
+                                            "type": "integer",
+                                            "example": 30,
+                                            "description": "The amount of results that is being returned per page."
+                                        },
+                                        "totalItems": {
+                                            "type": "integer",
+                                            "example": 2345,
+                                            "description": "Total amount of results for the given query parameters."
+                                        },
+                                        "member": {
+                                            "type": "array",
+                                            "description": "Search results (paginated). Note that the complete search results details will only be returned if `?embed=true` is used. Otherwise only the `@id` will be returned.",
+                                            "items": {
+                                                "$ref": "../models/event.json"
+                                            }
+                                        },
+                                        "facet": {
+                                            "type": "object",
+                                            "description": "Facet counts per possible filter & value.",
+                                            "properties": {
+                                                "regions": {
+                                                    "$ref": "../models/common-facets.json"
+                                                },
+                                                "types": {
+                                                    "$ref": "../models/common-facets.json"
+                                                },
+                                                "themes": {
+                                                    "$ref": "../models/common-facets.json"
+                                                },
+                                                "facilities": {
+                                                    "$ref": "../models/common-facets.json"
+                                                },
+                                                "labels": {
+                                                    "$ref": "../models/common-facets.json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "itemsPerPage",
+                                        "totalItems",
+                                        "member"
+                                    ]
+                                },
+                                "examples": {
+                                    "Example": {
+                                        "value": {
+                                            "itemsPerPage": 20,
+                                            "totalItems": 3,
+                                            "member": [
+                                                {
+                                                    "@id": "https://io-test.uitdatabank.be/event/7dc08012-488b-4e2b-b318-625d9bce03d7",
+                                                    "@type": "Event"
+                                                },
+                                                {
+                                                    "@id": "https://io-test.uitdatabank.be/event/c683ddfe-4ff9-4b4b-a198-b9f553cfc479",
+                                                    "@type": "Event"
+                                                },
+                                                {
+                                                    "@id": "https://io-test.uitdatabank.be/event/15d5de07-57e6-4015-84c6-e9c94ccfd9ef",
+                                                    "@type": "Event"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     },
-                    "totalItems": {
-                      "type": "integer",
-                      "example": 2345,
-                      "description": "Total amount of results for the given query parameters."
+                    "401": {
+                        "$ref": "#/components/responses/Unauthorized"
                     },
-                    "member": {
-                      "type": "array",
-                      "description": "Search results (paginated). Note that the complete search results details will only be returned if `?embed=true` is used. Otherwise only the `@id` and `@type` will be returned.",
-                      "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "../models/event.json"
-                          },
-                          {
-                            "$ref": "../models/place.json"
-                          }
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    }
+                },
+                "operationId": "get-events",
+                "description": "Returns a paginated list of events that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.\n\nAdd `embedCalendarSummaries` to have an extra property `calendarSummary` in the results that contains one or more formatted human-readable summaries of the date/time info of the result. See <a href=\"search-api/calendar-summaries\">the guide about embedding the calendar summaries</a> for more details.",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/x-client-id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/x-api-key"
+                    },
+                    {
+                        "$ref": "#/components/parameters/text"
+                    },
+                    {
+                        "$ref": "#/components/parameters/q"
+                    },
+                    {
+                        "$ref": "#/components/parameters/postalCode"
+                    },
+                    {
+                        "$ref": "#/components/parameters/addressCountry"
+                    },
+                    {
+                        "$ref": "#/components/parameters/maxAge"
+                    },
+                    {
+                        "$ref": "#/components/parameters/minAge"
+                    },
+                    {
+                        "$ref": "#/components/parameters/allAges"
+                    },
+                    {
+                        "$ref": "#/components/parameters/audienceType"
+                    },
+                    {
+                        "$ref": "#/components/parameters/availableFrom"
+                    },
+                    {
+                        "$ref": "#/components/parameters/availableTo"
+                    },
+                    {
+                        "$ref": "#/components/parameters/attendanceMode"
+                    },
+                    {
+                        "$ref": "#/components/parameters/bookingAvailability"
+                    },
+                    {
+                        "$ref": "#/components/parameters/calendarType"
+                    },
+                    {
+                        "$ref": "#/components/parameters/createdFrom"
+                    },
+                    {
+                        "$ref": "#/components/parameters/createdTo"
+                    },
+                    {
+                        "$ref": "#/components/parameters/modifiedFrom"
+                    },
+                    {
+                        "$ref": "#/components/parameters/modifiedTo"
+                    },
+                    {
+                        "$ref": "#/components/parameters/contributors"
+                    },
+                    {
+                        "$ref": "#/components/parameters/creator"
+                    },
+                    {
+                        "$ref": "#/components/parameters/dateFrom"
+                    },
+                    {
+                        "$ref": "#/components/parameters/dateTo"
+                    },
+                    {
+                        "$ref": "#/components/parameters/localTimeFrom"
+                    },
+                    {
+                        "$ref": "#/components/parameters/localTimeTo"
+                    },
+                    {
+                        "$ref": "#/components/parameters/embed"
+                    },
+                    {
+                        "$ref": "#/components/parameters/embedCalendarSummaries"
+                    },
+                    {
+                        "$ref": "#/components/parameters/embedUitpasPrices"
+                    },
+                    {
+                        "$ref": "#/components/parameters/facets"
+                    },
+                    {
+                        "$ref": "#/components/parameters/groupBy"
+                    },
+                    {
+                        "$ref": "#/components/parameters/regions"
+                    },
+                    {
+                        "$ref": "#/components/parameters/coordinates"
+                    },
+                    {
+                        "$ref": "#/components/parameters/distance"
+                    },
+                    {
+                        "$ref": "#/components/parameters/bounds"
+                    },
+                    {
+                        "$ref": "#/components/parameters/id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/locationId"
+                    },
+                    {
+                        "$ref": "#/components/parameters/organizerId"
+                    },
+                    {
+                        "$ref": "#/components/parameters/labels"
+                    },
+                    {
+                        "$ref": "#/components/parameters/locationLabels"
+                    },
+                    {
+                        "$ref": "#/components/parameters/organizerLabels"
+                    },
+                    {
+                        "$ref": "#/components/parameters/mainLanguage"
+                    },
+                    {
+                        "$ref": "#/components/parameters/languages"
+                    },
+                    {
+                        "$ref": "#/components/parameters/completedLanguages"
+                    },
+                    {
+                        "$ref": "#/components/parameters/hasMediaObjects"
+                    },
+                    {
+                        "$ref": "#/components/parameters/price"
+                    },
+                    {
+                        "$ref": "#/components/parameters/minPrice"
+                    },
+                    {
+                        "$ref": "#/components/parameters/maxPrice"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sortScore"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sortAvailableTo"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sortCreated"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sortModified"
+                    },
+                    {
+                        "$ref": "#/components/parameters/sortDistance"
+                    },
+                    {
+                        "$ref": "#/components/parameters/status"
+                    },
+                    {
+                        "$ref": "#/components/parameters/termIds"
+                    },
+                    {
+                        "$ref": "#/components/parameters/uitpas"
+                    },
+                    {
+                        "$ref": "#/components/parameters/hasVideos"
+                    },
+                    {
+                        "$ref": "#/components/parameters/workflowStatusOffer"
+                    }
+                ]
+            },
+            "parameters": [],
+            "security": [
+                {
+                    "CLIENT_IDENTIFICATION": []
+                },
+                {
+                    "CLIENT_ACCESS_TOKEN": []
+                },
+                {
+                    "USER_ACCESS_TOKEN": []
+                }
+            ],
+            "/offers": {
+                "get": {
+                    "summary": "Search events & places (offers)",
+                    "tags": [
+                        "Events & places"
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "A single page of search results. If `?embed=true` is used, the search results will contain the complete JSON details. Otherwise only `@id` and `@type` will be returned.",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "itemsPerPage": {
+                                                "type": "integer",
+                                                "example": 30,
+                                                "description": "The amount of results that is being returned per page."
+                                            },
+                                            "totalItems": {
+                                                "type": "integer",
+                                                "example": 2345,
+                                                "description": "Total amount of results for the given query parameters."
+                                            },
+                                            "member": {
+                                                "type": "array",
+                                                "description": "Search results (paginated). Note that the complete search results details will only be returned if `?embed=true` is used. Otherwise only the `@id` and `@type` will be returned.",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "../models/event.json"
+                                                        },
+                                                        {
+                                                            "$ref": "../models/place.json"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "facet": {
+                                                "type": "object",
+                                                "description": "Facet counts per possible filter & value.",
+                                                "properties": {
+                                                    "regions": {
+                                                        "$ref": "../models/common-facets.json"
+                                                    },
+                                                    "types": {
+                                                        "$ref": "../models/common-facets.json"
+                                                    },
+                                                    "themes": {
+                                                        "$ref": "../models/common-facets.json"
+                                                    },
+                                                    "facilities": {
+                                                        "$ref": "../models/common-facets.json"
+                                                    },
+                                                    "labels": {
+                                                        "$ref": "../models/common-facets.json"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "itemsPerPage",
+                                            "totalItems",
+                                            "member"
+                                        ]
+                                    },
+                                    "examples": {
+                                        "Example": {
+                                            "value": {
+                                                "itemsPerPage": 20,
+                                                "totalItems": 3,
+                                                "member": [
+                                                    {
+                                                        "@id": "https://io-test.uitdatabank.be/event/7dc08012-488b-4e2b-b318-625d9bce03d7",
+                                                        "@type": "Event"
+                                                    },
+                                                    {
+                                                        "@id": "https://io-test.uitdatabank.be/place/c683ddfe-4ff9-4b4b-a198-b9f553cfc479",
+                                                        "@type": "Place"
+                                                    },
+                                                    {
+                                                        "@id": "https://io-test.uitdatabank.be/event/15d5de07-57e6-4015-84c6-e9c94ccfd9ef",
+                                                        "@type": "Event"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "401": {
+                            "$ref": "#/components/responses/Unauthorized"
+                        },
+                        "403": {
+                            "$ref": "#/components/responses/Forbidden"
+                        },
+                        "404": {
+                            "$ref": "#/components/responses/NotFound"
+                        }
+                    },
+                    "operationId": "get-offers",
+                    "description": "Returns a paginated list of both events and places that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.",
+                    "parameters": [
+                        {
+                            "$ref": "#/components/parameters/x-client-id"
+                        },
+                        {
+                            "$ref": "#/components/parameters/x-api-key"
+                        },
+                        {
+                            "$ref": "#/components/parameters/text"
+                        },
+                        {
+                            "$ref": "#/components/parameters/q"
+                        },
+                        {
+                            "$ref": "#/components/parameters/postalCode"
+                        },
+                        {
+                            "$ref": "#/components/parameters/addressCountry"
+                        },
+                        {
+                            "$ref": "#/components/parameters/maxAge"
+                        },
+                        {
+                            "$ref": "#/components/parameters/minAge"
+                        },
+                        {
+                            "$ref": "#/components/parameters/allAges"
+                        },
+                        {
+                            "$ref": "#/components/parameters/audienceType"
+                        },
+                        {
+                            "$ref": "#/components/parameters/availableFrom"
+                        },
+                        {
+                            "$ref": "#/components/parameters/availableTo"
+                        },
+                        {
+                            "$ref": "#/components/parameters/attendanceMode"
+                        },
+                        {
+                            "$ref": "#/components/parameters/bookingAvailability"
+                        },
+                        {
+                            "$ref": "#/components/parameters/calendarType"
+                        },
+                        {
+                            "$ref": "#/components/parameters/createdFrom"
+                        },
+                        {
+                            "$ref": "#/components/parameters/createdTo"
+                        },
+                        {
+                            "$ref": "#/components/parameters/modifiedFrom"
+                        },
+                        {
+                            "$ref": "#/components/parameters/modifiedTo"
+                        },
+                        {
+                            "$ref": "#/components/parameters/contributors"
+                        },
+                        {
+                            "$ref": "#/components/parameters/creator"
+                        },
+                        {
+                            "$ref": "#/components/parameters/dateFrom"
+                        },
+                        {
+                            "$ref": "#/components/parameters/dateTo"
+                        },
+                        {
+                            "$ref": "#/components/parameters/localTimeFrom"
+                        },
+                        {
+                            "$ref": "#/components/parameters/localTimeTo"
+                        },
+                        {
+                            "$ref": "#/components/parameters/embed"
+                        },
+                        {
+                            "$ref": "#/components/parameters/embedCalendarSummaries"
+                        },
+                        {
+                            "$ref": "#/components/parameters/embedUitpasPrices"
+                        },
+                        {
+                            "$ref": "#/components/parameters/facets"
+                        },
+                        {
+                            "$ref": "#/components/parameters/groupBy"
+                        },
+                        {
+                            "$ref": "#/components/parameters/regions"
+                        },
+                        {
+                            "$ref": "#/components/parameters/coordinates"
+                        },
+                        {
+                            "$ref": "#/components/parameters/distance"
+                        },
+                        {
+                            "$ref": "#/components/parameters/bounds"
+                        },
+                        {
+                            "$ref": "#/components/parameters/id"
+                        },
+                        {
+                            "$ref": "#/components/parameters/isDuplicate"
+                        },
+                        {
+                            "$ref": "#/components/parameters/locationId"
+                        },
+                        {
+                            "$ref": "#/components/parameters/organizerId"
+                        },
+                        {
+                            "$ref": "#/components/parameters/labels"
+                        },
+                        {
+                            "$ref": "#/components/parameters/locationLabels"
+                        },
+                        {
+                            "$ref": "#/components/parameters/organizerLabels"
+                        },
+                        {
+                            "$ref": "#/components/parameters/mainLanguage"
+                        },
+                        {
+                            "$ref": "#/components/parameters/languages"
+                        },
+                        {
+                            "$ref": "#/components/parameters/completedLanguages"
+                        },
+                        {
+                            "$ref": "#/components/parameters/hasMediaObjects"
+                        },
+                        {
+                            "$ref": "#/components/parameters/price"
+                        },
+                        {
+                            "$ref": "#/components/parameters/minPrice"
+                        },
+                        {
+                            "$ref": "#/components/parameters/maxPrice"
+                        },
+                        {
+                            "$ref": "#/components/parameters/sortScore"
+                        },
+                        {
+                            "$ref": "#/components/parameters/sortAvailableTo"
+                        },
+                        {
+                            "$ref": "#/components/parameters/sortCreated"
+                        },
+                        {
+                            "$ref": "#/components/parameters/sortModified"
+                        },
+                        {
+                            "$ref": "#/components/parameters/sortDistance"
+                        },
+                        {
+                            "$ref": "#/components/parameters/status"
+                        },
+                        {
+                            "$ref": "#/components/parameters/termIds"
+                        },
+                        {
+                            "$ref": "#/components/parameters/uitpas"
+                        },
+                        {
+                            "$ref": "#/components/parameters/hasVideos"
+                        },
+                        {
+                            "$ref": "#/components/parameters/workflowStatusOffer"
+                        }
+                    ]
+                },
+                "parameters": [],
+                "security": [
+                    {
+                        "CLIENT_IDENTIFICATION": []
+                    },
+                    {
+                        "CLIENT_ACCESS_TOKEN": []
+                    },
+                    {
+                        "USER_ACCESS_TOKEN": []
+                    }
+                ],
+                "/organizers": {
+                    "get": {
+                        "summary": "Search organizers",
+                        "tags": [
+                            "Organizers"
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "A single page of search results. If `?embed=true` is used, the search results will contain the complete JSON details. Otherwise only `@id` and `@type` will be returned.",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "itemsPerPage": {
+                                                    "type": "integer",
+                                                    "example": 30,
+                                                    "description": "The amount of results that is being returned per page."
+                                                },
+                                                "totalItems": {
+                                                    "type": "integer",
+                                                    "example": 2345,
+                                                    "description": "Total amount of results for the given query parameters."
+                                                },
+                                                "member": {
+                                                    "type": "array",
+                                                    "description": "Search results (paginated). Note that the complete search results details will only be returned if `?embed=true` is used. Otherwise only the `@id` will be returned.",
+                                                    "items": {
+                                                        "$ref": "../models/organizer.json"
+                                                    }
+                                                },
+                                                "facet": {
+                                                    "type": "object",
+                                                    "description": "Facet counts per possible filter & value.",
+                                                    "properties": {
+                                                        "regions": {
+                                                            "$ref": "../models/common-facets.json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "itemsPerPage",
+                                                "totalItems",
+                                                "member"
+                                            ]
+                                        },
+                                        "examples": {
+                                            "Example": {
+                                                "value": {
+                                                    "itemsPerPage": 20,
+                                                    "totalItems": 3,
+                                                    "member": [
+                                                        {
+                                                            "@id": "https://io-test.uitdatabank.be/organizer/7dc08012-488b-4e2b-b318-625d9bce03d7",
+                                                            "@type": "Organizer"
+                                                        },
+                                                        {
+                                                            "@id": "https://io-test.uitdatabank.be/organizer/c683ddfe-4ff9-4b4b-a198-b9f553cfc479",
+                                                            "@type": "Organizer"
+                                                        },
+                                                        {
+                                                            "@id": "https://io-test.uitdatabank.be/organizer/15d5de07-57e6-4015-84c6-e9c94ccfd9ef",
+                                                            "@type": "Organizer"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "401": {
+                                "$ref": "#/components/responses/Unauthorized"
+                            },
+                            "403": {
+                                "$ref": "#/components/responses/Forbidden"
+                            },
+                            "404": {
+                                "$ref": "#/components/responses/NotFound"
+                            }
+                        },
+                        "operationId": "get-organizers",
+                        "description": "Returns a paginated list of organizers that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.",
+                        "parameters": [
+                            {
+                                "$ref": "#/components/parameters/x-client-id"
+                            },
+                            {
+                                "$ref": "#/components/parameters/x-api-key"
+                            },
+                            {
+                                "$ref": "#/components/parameters/q"
+                            },
+                            {
+                                "$ref": "#/components/parameters/name"
+                            },
+                            {
+                                "$ref": "#/components/parameters/website"
+                            },
+                            {
+                                "$ref": "#/components/parameters/id"
+                            },
+                            {
+                                "$ref": "#/components/parameters/domain"
+                            },
+                            {
+                                "$ref": "#/components/parameters/postalCode"
+                            },
+                            {
+                                "$ref": "#/components/parameters/addressCountry"
+                            },
+                            {
+                                "$ref": "#/components/parameters/creator"
+                            },
+                            {
+                                "$ref": "#/components/parameters/contributors"
+                            },
+                            {
+                                "$ref": "#/components/parameters/facets"
+                            },
+                            {
+                                "$ref": "#/components/parameters/regions"
+                            },
+                            {
+                                "$ref": "#/components/parameters/coordinates"
+                            },
+                            {
+                                "$ref": "#/components/parameters/embed"
+                            },
+                            {
+                                "$ref": "#/components/parameters/distance"
+                            },
+                            {
+                                "$ref": "#/components/parameters/bounds"
+                            },
+                            {
+                                "$ref": "#/components/parameters/labels"
+                            },
+                            {
+                                "$ref": "#/components/parameters/hasImages"
+                            },
+                            {
+                                "$ref": "#/components/parameters/workflowStatusOrganizer"
+                            },
+                            {
+                                "$ref": "#/components/parameters/sortScore"
+                            },
+                            {
+                                "$ref": "#/components/parameters/sortCreated"
+                            },
+                            {
+                                "$ref": "#/components/parameters/sortModified"
+                            }
                         ]
-                      }
                     },
-                    "facet": {
-                      "type": "object",
-                      "description": "Facet counts per possible filter & value.",
-                      "properties": {
+                    "parameters": [],
+                    "security": [
+                        {
+                            "CLIENT_IDENTIFICATION": []
+                        },
+                        {
+                            "CLIENT_ACCESS_TOKEN": []
+                        },
+                        {
+                            "USER_ACCESS_TOKEN": []
+                        }
+                    ],
+                    "/places": {
+                        "get": {
+                            "summary": "Search places",
+                            "tags": [
+                                "Events & places"
+                            ],
+                            "responses": {
+                                "200": {
+                                    "description": "A single page of search results. If `?embed=true` is used, the search results will contain the complete JSON details. Otherwise only `@id` and `@type` will be returned.",
+                                    "content": {
+                                        "application/json": {
+                                            "schema": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "itemsPerPage": {
+                                                        "type": "integer",
+                                                        "example": 30,
+                                                        "description": "The amount of results that is being returned per page."
+                                                    },
+                                                    "totalItems": {
+                                                        "type": "integer",
+                                                        "example": 2345,
+                                                        "description": "Total amount of results for the given query parameters."
+                                                    },
+                                                    "member": {
+                                                        "type": "array",
+                                                        "description": "Search results (paginated). Note that the complete search results details will only be returned if `?embed=true` is used. Otherwise only the `@id` will be returned.",
+                                                        "items": {
+                                                            "$ref": "../models/place.json"
+                                                        }
+                                                    },
+                                                    "facet": {
+                                                        "type": "object",
+                                                        "description": "Facet counts per possible filter & value.",
+                                                        "properties": {
+                                                            "regions": {
+                                                                "$ref": "../models/common-facets.json"
+                                                            },
+                                                            "types": {
+                                                                "$ref": "../models/common-facets.json"
+                                                            },
+                                                            "themes": {
+                                                                "$ref": "../models/common-facets.json"
+                                                            },
+                                                            "facilities": {
+                                                                "$ref": "../models/common-facets.json"
+                                                            },
+                                                            "labels": {
+                                                                "$ref": "../models/common-facets.json"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "itemsPerPage",
+                                                    "totalItems",
+                                                    "member"
+                                                ]
+                                            },
+                                            "examples": {
+                                                "Example": {
+                                                    "value": {
+                                                        "itemsPerPage": 20,
+                                                        "totalItems": 3,
+                                                        "member": [
+                                                            {
+                                                                "@id": "https://io-test.uitdatabank.be/place/7dc08012-488b-4e2b-b318-625d9bce03d7",
+                                                                "@type": "Place"
+                                                            },
+                                                            {
+                                                                "@id": "https://io-test.uitdatabank.be/place/c683ddfe-4ff9-4b4b-a198-b9f553cfc479",
+                                                                "@type": "Place"
+                                                            },
+                                                            {
+                                                                "@id": "https://io-test.uitdatabank.be/place/15d5de07-57e6-4015-84c6-e9c94ccfd9ef",
+                                                                "@type": "Place"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "401": {
+                                    "$ref": "#/components/responses/Unauthorized"
+                                },
+                                "403": {
+                                    "$ref": "#/components/responses/Forbidden"
+                                },
+                                "404": {
+                                    "$ref": "#/components/responses/NotFound"
+                                }
+                            },
+                            "operationId": "get-places",
+                            "description": "Returns a paginated list of places that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.\n\nAdd `embedCalendarSummaries` to have an extra property `calendarSummary` in the results that contains one or more formatted human-readable summaries of the date/time info of the result. See <a href=\"search-api/calendar-summaries\">the guide about embedding the calendar summaries</a> for more details.\n",
+                            "parameters": [
+                                {
+                                    "$ref": "#/components/parameters/x-client-id"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/x-api-key"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/text"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/q"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/postalCode"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/addressCountry"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/maxAge"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/minAge"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/allAges"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/audienceType"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/availableFrom"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/availableTo"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/attendanceMode"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/bookingAvailability"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/calendarType"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/createdFrom"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/createdTo"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/embed"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/embedCalendarSummaries"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/embedUitpasPrices"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/modifiedFrom"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/modifiedTo"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/contributors"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/creator"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/dateFrom"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/dateTo"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/localTimeFrom"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/localTimeTo"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/facets"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/groupBy"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/regions"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/coordinates"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/distance"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/bounds"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/id"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/isDuplicate"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/locationId"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/organizerId"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/labels"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/organizerLabels"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/mainLanguage"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/languages"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/completedLanguages"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/hasMediaObjects"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/price"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/minPrice"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/maxPrice"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/sortScore"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/sortAvailableTo"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/sortCreated"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/sortModified"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/sortDistance"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/status"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/termIds"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/uitpas"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/hasVideos"
+                                },
+                                {
+                                    "$ref": "#/components/parameters/workflowStatusOffer"
+                                }
+                            ]
+                        },
+                        "parameters": [],
+                        "security": [
+                            {
+                                "CLIENT_IDENTIFICATION": []
+                            },
+                            {
+                                "CLIENT_ACCESS_TOKEN": []
+                            },
+                            {
+                                "USER_ACCESS_TOKEN": []
+                            }
+                        ]
+                    }
+                },
+                "tags": [
+                    {
+                        "name": "Events & places"
+                    },
+                    {
+                        "name": "Organizers"
+                    }
+                ],
+                "components": {
+                    "securitySchemes": {},
+                    "schemas": {
+                        "Error": {
+                            "$ref": "https://raw.githubusercontent.com/cultuurnet/apidocs/main/projects/errors/models/Error.json",
+                            "x-internal": true
+                        }
+                    },
+                    "parameters": {
+                        "x-client-id": {
+                            "schema": {
+                                "type": "string"
+                            },
+                            "in": "header",
+                            "name": "x-client-id",
+                            "description": "The client id of your project (if not using an API key). May also be replaced with a `clientId` query parameter."
+                        },
+                        "x-api-key": {
+                            "schema": {
+                                "type": "string"
+                            },
+                            "in": "header",
+                            "name": "x-api-key",
+                            "description": "The API key of your project on https://projectaanvraag.uitdatabank.be (if not using a client id). May also be replaced with an `apiKey` query parameter. Will be deprecated in favour of `x-client-id` in the future, but will still be supported.",
+                            "deprecated": true
+                        },
+                        "text": {
+                            "schema": {
+                                "type": "string",
+                                "example": " dijle (wandelen OR fietsen)"
+                            },
+                            "in": "query",
+                            "name": "text",
+                            "description": "Free text search terms. Returns results that match all or some of the given terms. May contain `AND` and `OR` operators, and brackets for grouping. Can not filter on specific fields (contrary to the `q` parameter). Typically used to search on user-provided keywords."
+                        },
+                        "q": {
+                            "schema": {
+                                "type": "string",
+                                "example": "labels:\"ook voor kinderen\" OR labels:\"ook voor jongeren\""
+                            },
+                            "in": "query",
+                            "name": "q",
+                            "description": "An advanced query in Lucene syntax, allowing you to construct complex AND/OR filters on specific fields."
+                        },
+                        "contributors": {
+                            "schema": {
+                                "format": "email",
+                                "type": "string",
+                                "example": "technical-support@publiq.be"
+                            },
+                            "in": "query",
+                            "name": "contributors",
+                            "description": "Returns results for which a particular user / email address is a contributor"
+                        },
+                        "name": {
+                            "schema": {
+                                "type": "string",
+                                "example": "publiq"
+                            },
+                            "in": "query",
+                            "name": "name",
+                            "description": "Returns only results whose name autocompletes on the given name. For example searching for `pub` will return matches with `publiq` in the name."
+                        },
+                        "website": {
+                            "schema": {
+                                "type": "string",
+                                "example": "https://www.publiq.be/example"
+                            },
+                            "in": "query",
+                            "name": "website",
+                            "description": "Returns only results that have the given URL as their website. URLs in the query parameter and on the search results are normalized to reduce false negatives."
+                        },
+                        "domain": {
+                            "schema": {
+                                "type": "string",
+                                "example": "www.publiq.be"
+                            },
+                            "in": "query",
+                            "name": "domain",
+                            "description": "Returns only results that have a website on the given domain. Domains in the query parameter and on the search results are normalized to reduce false negatives."
+                        },
+                        "postalCode": {
+                            "schema": {
+                                "type": "string",
+                                "example": "1000"
+                            },
+                            "in": "query",
+                            "name": "postalCode",
+                            "description": "Returns only results that have the exact same postal code in their address. Typically 4 digits for Belgian addresses but can also be a different format for international addresses."
+                        },
+                        "isDuplicate": {
+                            "schema": {
+                                "type": "boolean"
+                            },
+                            "in": "query",
+                            "name": "isDuplicate",
+                            "description": "Returns only results that include or excludes duplicate places"
+                        },
+                        "embed": {
+                            "schema": {
+                                "type": "boolean"
+                            },
+                            "in": "query",
+                            "name": "embed",
+                            "description": "Returns the results with the actual JSON bodies of the individual items"
+                        },
+                        "embedUitpasPrices": {
+                            "schema": {
+                                "type": "boolean"
+                            },
+                            "in": "query",
+                            "name": "embedUitpasPrices",
+                            "description": "Returns the results with the UiTPAS prices included (if applicable)"
+                        },
+                        "addressCountry": {
+                            "schema": {
+                                "type": "string",
+                                "example": "BE",
+                                "pattern": "^[A-Z][A-Z]$",
+                                "default": "BE"
+                            },
+                            "in": "query",
+                            "name": "addressCountry",
+                            "description": "Returns only results that have the exact same country code in their address. Formatted as an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. The default value can be disabled by setting the value to `*` or by using the `disableDefaultFilters` query parameter."
+                        },
+                        "maxAge": {
+                            "schema": {
+                                "type": "integer",
+                                "example": 18
+                            },
+                            "in": "query",
+                            "name": "maxAge",
+                            "description": "Returns only results that are targeted to participants/visitors of at most the given age (in years). The given age will be included in results."
+                        },
+                        "minAge": {
+                            "schema": {
+                                "type": "integer",
+                                "example": 12
+                            },
+                            "in": "query",
+                            "name": "minAge",
+                            "description": "Returns only results that are targeted to participants/visitors of at least the given age (in years). The given age will be included in results."
+                        },
+                        "allAges": {
+                            "schema": {
+                                "type": "boolean"
+                            },
+                            "in": "query",
+                            "name": "allAges",
+                            "description": "Returns only results that are suitable for participants/visitors of all ages if set to `true`, or only returns results that are suitable for a specific age group if set to `false`."
+                        },
+                        "audienceType": {
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "everyone",
+                                    "members",
+                                    "education"
+                                ],
+                                "default": "everyone"
+                            },
+                            "in": "query",
+                            "name": "audienceType",
+                            "description": "Returns only results with the given enum value as their targeted audience. Results with audienceType `everyone` are targeted to any participant/visitor. Results with audienceType `members` are only targeted towards members of the organizer of the event. Results with audienceType `education` are targeted towards [CultuurKuur](https://www.cultuurkuur.be/)."
+                        },
+                        "availableFrom": {
+                            "schema": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2022-03-04T10:30:00+01:00"
+                            },
+                            "in": "query",
+                            "name": "availableFrom",
+                            "description": "Returns only results that should (still) be visible on online calendars after the given date-time. Defaults to the current date-time of the request. The default value can be disabled by setting the value to `*` or by using the `disableDefaultFilters` query parameter. See (the guide about default filters)[../docs/search-api/common-filters/default-filters.md] for more information."
+                        },
+                        "availableTo": {
+                            "schema": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2022-03-05T10:30:00+01:00"
+                            },
+                            "in": "query",
+                            "name": "availableTo",
+                            "description": "Returns only results that should be visible on online calendars up until the given date-time. Defaults to the current date-time of the request. The default value can be disabled by setting the value to `*` or by using the `disableDefaultFilters` query parameter. See (the guide about default filters)[../docs/search-api/common-filters/default-filters.md] for more information."
+                        },
+                        "attendanceMode": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "online",
+                                        "offline",
+                                        "mixed"
+                                    ]
+                                }
+                            },
+                            "in": "query",
+                            "name": "attendanceMode",
+                            "description": "Returns only results with the given enum value as their attendance mode. Results with attendanceMode `online` are only happening online (e.g. via a video stream). Results with attendanceMode `offline` are only happening on a physical location. Results with attendanceMode `mixed` can be attended both online or offline. Note that when filtering on `mixed`, _only_ results that are both happening online and offline will be included. Accepts multiple comma-separated values to return results that have one of the given attendance modes.",
+                            "style": "form",
+                            "explode": false
+                        },
+                        "bookingAvailability": {
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "Available",
+                                    "Unavailable"
+                                ]
+                            },
+                            "in": "query",
+                            "name": "bookingAvailability",
+                            "description": "Returns only results with the given enum value as their bookingAvailability type. Results with bookingAvailability `Available` still have tickets/reservations available. Results with bookingAvailability `Unavailable` are sold out / fully booked."
+                        },
+                        "calendarType": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "single",
+                                        "multiple",
+                                        "periodic",
+                                        "permanent"
+                                    ]
+                                }
+                            },
+                            "style": "form",
+                            "explode": false,
+                            "in": "query",
+                            "name": "calendarType",
+                            "description": "Returns only results with the given enum value as their calendarType. Accepts multiple comma-separated values to return results that have one of the given calendar types. [Here is a detailed guide](./entry-api/shared/calendar-info#calendartype) with more information."
+                        },
+                        "createdFrom": {
+                            "schema": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2022-03-04T10:30:00+01:00"
+                            },
+                            "in": "query",
+                            "name": "createdFrom",
+                            "description": "Returns only results that were created at or after the given date-time."
+                        },
+                        "createdTo": {
+                            "schema": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2022-03-05T10:30:00+01:00"
+                            },
+                            "in": "query",
+                            "name": "createdTo",
+                            "description": "Returns only results that were created at or before the given date-time."
+                        },
+                        "modifiedFrom": {
+                            "schema": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2022-03-04T10:30:00+01:00"
+                            },
+                            "in": "query",
+                            "name": "modifiedFrom",
+                            "description": "Returns only results that were last modified at or after the given date-time. If the result has never been modified, the `created` date-time will be used as `modified` instead."
+                        },
+                        "modifiedTo": {
+                            "schema": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2022-03-05T10:30:00+01:00"
+                            },
+                            "in": "query",
+                            "name": "modifiedTo",
+                            "description": "Returns only results that were last modified at or before the given date-time. If the result has never been modified, the `created` date-time will be used as `modified` instead."
+                        },
+                        "creator": {
+                            "schema": {
+                                "type": "string",
+                                "example": "lxBfdgJwUaJUgm7CBCeKF2eE2fnsyLCB@clients"
+                            },
+                            "in": "query",
+                            "name": "creator",
+                            "description": "Returns only results that have a creator with the given user identifier. Due to historic reasons and evolutions in the id management systems, a user identifier can be one of: a UUID (for creators that had an UiTiD v1), an Auth0 user id (for new UiTiD v2 creators), or in some very old cases even an email address or nickname. (No new events or places are created with an email address or nickname as creator.) Can also be a client id suffixed with `@clients` in the case of results created with a client access token instead of a user access token."
+                        },
+                        "dateFrom": {
+                            "schema": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2022-03-04T10:30:00+01:00"
+                            },
+                            "in": "query",
+                            "name": "dateFrom",
+                            "description": "Returns only events that are happening at some point after the given date-time, and places that are open at some point after the given date-time. Permanent events or places are always returned by this parameter."
+                        },
+                        "dateTo": {
+                            "schema": {
+                                "type": "string",
+                                "format": "date-time",
+                                "example": "2022-03-05T10:30:00+01:00"
+                            },
+                            "in": "query",
+                            "name": "dateTo",
+                            "description": "Returns only events that are happening at some point before the given date-time, and places that are open at some point before the given date-time. Permanent events or places are always returned by this parameter."
+                        },
+                        "localTimeFrom": {
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^([01]\\d|2[0123]):([012345]\\d)$",
+                                "example": "08:30"
+                            },
+                            "in": "query",
+                            "name": "localTimeFrom",
+                            "description": "Returns only events that are happening at some point after the given time, and places that are open at some point after the given time. Dates and timezones are not taken into account by this parameter. Permanent events or places are always returned by this parameter."
+                        },
+                        "localTimeTo": {
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^([01]\\d|2[0123]):([012345]\\d)$",
+                                "example": "23:59"
+                            },
+                            "in": "query",
+                            "name": "localTimeTo",
+                            "description": "Returns only events that are happening at some point before the given time, and places that are open at some point before the given time. Dates and timezones are not taken into account by this parameter. Permanent events or places are always returned by this parameter."
+                        },
+                        "embedCalendarSummaries": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "xs-text",
+                                        "sm-text",
+                                        "md-text",
+                                        "lg-text",
+                                        "xs-html",
+                                        "sm-html",
+                                        "md-html",
+                                        "lg-html"
+                                    ]
+                                }
+                            },
+                            "in": "query",
+                            "name": "embedCalendarSummaries[]",
+                            "description": "Adds an extra `calendarSummary` property to the results that contains one or more formatted human-readable summaries of the date/time info of the result. May be repeated to include multiple summaries per result. See the operation's description above for more info on how to repeat parameters.",
+                            "style": "form",
+                            "explode": true
+                        },
+                        "facets": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "regions",
+                                        "types",
+                                        "themes",
+                                        "facilities",
+                                        "labels"
+                                    ]
+                                }
+                            },
+                            "in": "query",
+                            "name": "facets[]",
+                            "description": "Adds an extra `facet` property in the response with possible values for a given filter, and a prediction of the total results if applied. May be repeated to include facet counts for multiple filters. See the operation's description above for more info on how to repeat parameters. See (the guide about facets)[../docs/search-api/advanced/facets.md] for more information.",
+                            "style": "form",
+                            "explode": true
+                        },
                         "regions": {
-                          "$ref": "../models/common-facets.json"
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "in": "query",
+                            "name": "regions[]",
+                            "description": "Returns only results that are geographically located in the given region. Regions may be fetched programmatically from [https://search.uitdatabank.be/autocomplete.json](https://search.uitdatabank.be/autocomplete.json).",
+                            "style": "form",
+                            "explode": true
                         },
-                        "types": {
-                          "$ref": "../models/common-facets.json"
+                        "coordinates": {
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$",
+                                "example": "50.8511740,4.338674"
+                            },
+                            "in": "query",
+                            "name": "coordinates",
+                            "description": "A pair of latitude and longitude coordinates to find results that are located within a distance of the given geographical point. Must be used in combination with the `distance` parameter."
                         },
-                        "themes": {
-                          "$ref": "../models/common-facets.json"
+                        "distance": {
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^\\s*(\\d+\\.?\\d*)\\s*(mi|miles|yd|yards|ft|feet|in|inch|km|kilometers|m|meters|cm|centimeters|mm|millimeters|NM|nmi|nauticalmiles)\\s*$",
+                                "example": "10km"
+                            },
+                            "in": "query",
+                            "name": "distance",
+                            "description": "Returns only results that are geographically located within the given distance from the `coordinates` parameter."
                         },
-                        "facilities": {
-                          "$ref": "../models/common-facets.json"
+                        "bounds": {
+                            "schema": {
+                                "type": "string",
+                                "example": "34.172684,-118.604794|34.236144,-118.500938",
+                                "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)\\|[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
+                            },
+                            "in": "query",
+                            "name": "bounds",
+                            "description": "Returns only results that are located in a specific geographical area defined by a pair of south-west coordinates and north-east coordinates. The two pairs of coordinates are separated by a pipe character (`|`)."
+                        },
+                        "groupBy": {
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "productionId"
+                                ]
+                            },
+                            "in": "query",
+                            "name": "groupBy",
+                            "description": "Groups the results by their production. Grouping by productions ensures that for every production, only 1 event is returned in the search results"
+                        },
+                        "id": {
+                            "schema": {
+                                "type": "string",
+                                "example": "f29d2182-2db0-4f99-831a-8e6a64c1c9c1"
+                            },
+                            "in": "query",
+                            "name": "id",
+                            "description": "Returns only results that have the exact same id. An id can be extracted from an event, place, or organizer URI by taking all the characters after the last `/`. For example for the URI `https://io.uitdatabank.be/event/75573a64-ddc8-4fd0-8b07-d258939dd74f` the id is `75573a64-ddc8-4fd0-8b07-d258939dd74f`. Note that while it will be a UUID in most cases, it is not guaranteed to always be one!"
+                        },
+                        "locationId": {
+                            "schema": {
+                                "type": "string",
+                                "example": "a0368d10-ded0-4925-b94a-2835f73e255e"
+                            },
+                            "in": "query",
+                            "name": "locationId",
+                            "description": "Returns only results that are related to the given location id (= place id). A place's id can be extracted from its URI by taking all the characters after the last `/`. For example for the URI `https://io.uitdatabank.be/place/75573a64-ddc8-4fd0-8b07-d258939dd74f` the id is `75573a64-ddc8-4fd0-8b07-d258939dd74f`. Note that while it will be a UUID in most cases, it is not guaranteed to always be one!"
+                        },
+                        "organizerId": {
+                            "schema": {
+                                "type": "string",
+                                "example": "4fa5dddf-73d5-47f8-b54f-45d88cc1661a"
+                            },
+                            "in": "query",
+                            "name": "organizerId",
+                            "description": "Returns only results that are related to the given organizer id. An organizer's id can be extracted from its URI by taking all the characters after the last `/`. For example for the URI `https://io.uitdatabank.be/organizer/75573a64-ddc8-4fd0-8b07-d258939dd74f` the id is `75573a64-ddc8-4fd0-8b07-d258939dd74f`. Note that while it will be a UUID in most cases, it is not guaranteed to always be one!"
                         },
                         "labels": {
-                          "$ref": "../models/common-facets.json"
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "itemsPerPage",
-                    "totalItems",
-                    "member"
-                  ]
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "itemsPerPage": 20,
-                      "totalItems": 3,
-                      "member": [
-                        {
-                          "@id": "https://io-test.uitdatabank.be/event/7dc08012-488b-4e2b-b318-625d9bce03d7",
-                          "@type": "Event"
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "in": "query",
+                            "name": "labels[]",
+                            "style": "form",
+                            "description": "Returns only results that have the given label(s) in either their `labels` or `hiddenLabels` properties. May be repeated to only return results that have all the given labels. See the operation's description above for more info on how to repeat parameters.",
+                            "explode": true
                         },
-                        {
-                          "@id": "https://io-test.uitdatabank.be/place/c683ddfe-4ff9-4b4b-a198-b9f553cfc479",
-                          "@type": "Place"
+                        "locationLabels": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "in": "query",
+                            "name": "locationLabels[]",
+                            "style": "form",
+                            "description": "Returns only results that have the given label(s) in their location's `labels` or `hiddenLabels` properties. May be repeated to only return results with a location that has all the given labels. See the operation's description above for more info on how to repeat parameters.",
+                            "explode": true
                         },
-                        {
-                          "@id": "https://io-test.uitdatabank.be/event/15d5de07-57e6-4015-84c6-e9c94ccfd9ef",
-                          "@type": "Event"
+                        "organizerLabels": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "in": "query",
+                            "name": "organizerLabels[]",
+                            "style": "form",
+                            "description": "Returns only results that have the given label(s) in their organizer's `labels` or `hiddenLabels` properties. May be repeated to only return results with an organizer that has all the given labels. See the operation's description above for more info on how to repeat parameters.",
+                            "explode": true
+                        },
+                        "mainLanguage": {
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^[a-z][a-z]$",
+                                "enum": [
+                                    "nl",
+                                    "fr",
+                                    "de",
+                                    "en"
+                                ]
+                            },
+                            "in": "query",
+                            "name": "mainLanguage",
+                            "description": "Returns only results that have the given language code as their main (= original) language."
+                        },
+                        "languages": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "pattern": "^[a-z][a-z]$",
+                                    "enum": [
+                                        "nl",
+                                        "fr",
+                                        "de",
+                                        "en"
+                                    ]
+                                }
+                            },
+                            "in": "query",
+                            "name": "languages[]",
+                            "style": "form",
+                            "description": "Returns only results that have a localised value in the given language for one or more translatable fields like `name`. May be repeated to only return results that have localised values for all the given languages. See the operation's description above for more info on how to repeat parameters.",
+                            "explode": true
+                        },
+                        "completedLanguages": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "pattern": "^[a-z][a-z]$",
+                                    "enum": [
+                                        "nl",
+                                        "fr",
+                                        "de",
+                                        "en"
+                                    ]
+                                }
+                            },
+                            "in": "query",
+                            "name": "completedLanguages[]",
+                            "style": "form",
+                            "description": "Returns only results that have a localised value in the given language for every translatable field. May be repeated to only return results that have localised values for all the given languages. See the operation's description above for more info on how to repeat parameters.",
+                            "explode": true
+                        },
+                        "hasMediaObjects": {
+                            "schema": {
+                                "type": "boolean"
+                            },
+                            "in": "query",
+                            "name": "hasMediaObjects",
+                            "description": "Returns only results that have one or more items inside their `mediaObject` property if set to `true`. Returns only results without `mediaObject` property if set to `false`."
+                        },
+                        "hasImages": {
+                            "schema": {
+                                "type": "boolean"
+                            },
+                            "in": "query",
+                            "name": "hasImages",
+                            "description": "Returns only results that have one or more items inside their `images` property if set to `true`. Returns only results without `images` property if set to `false`."
+                        },
+                        "price": {
+                            "schema": {
+                                "type": "number",
+                                "example": 5.75
+                            },
+                            "in": "query",
+                            "name": "price",
+                            "description": "Returns only results with exactly the same price for the base tariff (in EUR)."
+                        },
+                        "minPrice": {
+                            "schema": {
+                                "type": "number",
+                                "example": 5.75
+                            },
+                            "in": "query",
+                            "name": "minPrice",
+                            "description": "Returns only results with a price for the base tariff that is equal to or higher than the given price (in EUR)."
+                        },
+                        "maxPrice": {
+                            "schema": {
+                                "type": "number"
+                            },
+                            "in": "query",
+                            "name": "maxPrice",
+                            "description": "Returns only results with a price for the base tariff that is equal to or lower than the given price (in EUR)."
+                        },
+                        "sortScore": {
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "asc",
+                                    "desc"
+                                ]
+                            },
+                            "in": "query",
+                            "name": "sort[score]",
+                            "description": "Sorts the results by their score (relevance), either with the lowest score first (`asc`) or the highest score first (`desc`). See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
+                        },
+                        "sortAvailableTo": {
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "asc",
+                                    "desc"
+                                ]
+                            },
+                            "in": "query",
+                            "name": "sort[availableTo]",
+                            "description": "Sorts the results by their `availableTo` date-time, either with the oldest date-time first (`asc`) or the highest date-time first (`desc`). Most commonly used to show events and/or places that will end or become unavailable soon. See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
+                        },
+                        "sortCreated": {
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "asc",
+                                    "desc"
+                                ]
+                            },
+                            "in": "query",
+                            "name": "sort[created]",
+                            "description": "Sorts the results by their `created` date-time, either with the oldest results first (`asc`) or the newest results first (`desc`). See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
+                        },
+                        "sortModified": {
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "asc",
+                                    "desc"
+                                ]
+                            },
+                            "in": "query",
+                            "name": "sort[modified]",
+                            "description": "Sorts the results by their `modified` date-time, either with the least recently modified results first (`asc`) or the most recently modified results first (`desc`). See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
+                        },
+                        "sortDistance": {
+                            "schema": {
+                                "type": "string",
+                                "enum": [
+                                    "asc",
+                                    "desc"
+                                ]
+                            },
+                            "in": "query",
+                            "name": "sort[distance]",
+                            "description": "Sorts the results by their distance from the `coordinates` parameter. Can only be used if `coordinates` and `distance` are also set. You may use multiple sort parameters. See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
+                        },
+                        "status": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "Available",
+                                        "TemporarilyUnavailable",
+                                        "Unavailable"
+                                    ]
+                                }
+                            },
+                            "in": "query",
+                            "style": "form",
+                            "explode": false,
+                            "name": "status",
+                            "description": "Returns only results with exactly the same status type as the given enum value. `Available` means an event is happening as planned, and a place can be visited during its normal opening hours. `TemporarilyUnavailable` means an event has been postponed to a later date (yet to be determined), and a place is temporarily closed (for example due to renovations). `Unavailable` means an event is cancelled, or a place is permanently closed. If combined with `dateFrom` and/or `dateTo`, only results that have the given status in that time period will be returned. Accepts multiple comma-separated values to return results that have one of the given status types."
+                        },
+                        "termIds": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "in": "query",
+                            "name": "termIds[]",
+                            "style": "form",
+                            "description": "Returns only results that have the given term id(s) in either their `terms` property items. May be repeated to only return results that have all the given term ids. See the operation's description above for more info on how to repeat parameters.",
+                            "explode": true
+                        },
+                        "uitpas": {
+                            "schema": {
+                                "type": "boolean"
+                            },
+                            "in": "query",
+                            "name": "uitpas",
+                            "description": "Returns only results that are related to UiTPAS if set to `true`. Returns only results that are not related to UiTPAS if set to `false`."
+                        },
+                        "hasVideos": {
+                            "schema": {
+                                "type": "boolean"
+                            },
+                            "in": "query",
+                            "name": "hasVideos",
+                            "description": "Returns only results that have one or more items in their `videos` property if set to `true`. Returns only results that have no `videos` property if set to `false`."
+                        },
+                        "workflowStatusOffer": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "DRAFT",
+                                        "READY_FOR_VALIDATION",
+                                        "APPROVED",
+                                        "REJECTED",
+                                        "DELETED",
+                                        "*"
+                                    ],
+                                    "example": "DRAFT"
+                                }
+                            },
+                            "style": "form",
+                            "explode": false,
+                            "in": "query",
+                            "name": "workflowStatus",
+                            "description": "Returns only results with exactly the same workflow status as the given enum value. Accepts multiple comma-separated values to return results that have one of the given workflow statuses. Defaults to only return results that either have the workflow status `READY_FOR_VALIDATION` or `APPROVED`. The default value can be reset by setting the parameter to `*`. See (the guide about default filters)[../docs/search-api/common-filters/default-filters.md] for more information."
+                        },
+                        "workflowStatusOrganizer": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "ACTIVE",
+                                        "DELETED",
+                                        "*"
+                                    ],
+                                    "example": "ACTIVE"
+                                }
+                            },
+                            "style": "form",
+                            "explode": false,
+                            "in": "query",
+                            "name": "workflowStatus",
+                            "description": "Returns only results with exactly the same workflow status as the given enum value. Accepts multiple comma-separated values to return results that have one of the given workflow statuses. Defaults to only return results that have the workflow status `ACTIVE`. The default value can be reset by setting the parameter to `*`. See (the guide about default filters)[../docs/search-api/common-filters/default-filters.md] for more information."
                         }
-                      ]
+                    },
+                    "responses": {
+                        "Unauthorized": {
+                            "description": "Unauthorized. Your request is missing the required credentials to authenticate. See the Authentication documentation for more info.\n\n* type: https://api.publiq.be/probs/auth/unauthorized\n* detail: might contain a developer-readable explanation of the reason",
+                            "content": {
+                                "application/problem+json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/Error"
+                                    },
+                                    "examples": {
+                                        "Example": {
+                                            "value": {
+                                                "type": "https://api.publiq.be/probs/auth/unauthorized",
+                                                "title": "Unauthorized",
+                                                "status": 401
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "Forbidden": {
+                            "description": "Forbidden. Your request was successfully authenticated but you do not have permission to perform this particular request.\n\n* type: https://api.publiq.be/probs/auth/forbidden\n* detail: might contain a developer-readable explanation of the reason",
+                            "content": {
+                                "application/problem+json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/Error"
+                                    },
+                                    "examples": {
+                                        "Example": {
+                                            "value": {
+                                                "type": "https://api.publiq.be/probs/auth/forbidden",
+                                                "title": "Forbidden",
+                                                "status": 403,
+                                                "detail": "user must be admin of organizer abcd1234"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "NotFound": {
+                            "description": "The requested resource (URL) could not be found.\nThis can be due to one of multiple reasons:\n\n* The endpoint has a typo and/or does not exist on the API\n* One of the path parameters contains a value that is invalid or does not exist\n* One of the required query parameters is missing\n* One of the query parameters has an invalid value\n\nThe `detail` property of the response should contain more specific information.\n\nThe `type` will always be `https://api.publiq.be/probs/url/not-found`.",
+                            "content": {
+                                "application/problem+json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/Error"
+                                    },
+                                    "examples": {
+                                        "Example": {
+                                            "value": {
+                                                "type": "https://api.publiq.be/probs/url/not-found",
+                                                "title": "URL not found",
+                                                "status": 404,
+                                                "detail": "The resource with id \"76C6AC08-763C-492E-A68C-CBC43A857229\" was not found."
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
-                  }
                 }
-              }
             }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        },
-        "operationId": "get-offers",
-        "description": "Returns a paginated list of both events and places that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/x-client-id"
-          },
-          {
-            "$ref": "#/components/parameters/x-api-key"
-          },
-          {
-            "$ref": "#/components/parameters/text"
-          },
-          {
-            "$ref": "#/components/parameters/q"
-          },
-          {
-            "$ref": "#/components/parameters/postalCode"
-          },
-          {
-            "$ref": "#/components/parameters/addressCountry"
-          },
-          {
-            "$ref": "#/components/parameters/maxAge"
-          },
-          {
-            "$ref": "#/components/parameters/minAge"
-          },
-          {
-            "$ref": "#/components/parameters/allAges"
-          },
-          {
-            "$ref": "#/components/parameters/audienceType"
-          },
-          {
-            "$ref": "#/components/parameters/availableFrom"
-          },
-          {
-            "$ref": "#/components/parameters/availableTo"
-          },
-          {
-            "$ref": "#/components/parameters/attendanceMode"
-          },
-          {
-            "$ref": "#/components/parameters/bookingAvailability"
-          },
-          {
-            "$ref": "#/components/parameters/calendarType"
-          },
-          {
-            "$ref": "#/components/parameters/createdFrom"
-          },
-          {
-            "$ref": "#/components/parameters/createdTo"
-          },
-          {
-            "$ref": "#/components/parameters/modifiedFrom"
-          },
-          {
-            "$ref": "#/components/parameters/modifiedTo"
-          },
-          {
-            "$ref": "#/components/parameters/contributors"
-          },
-          {
-            "$ref": "#/components/parameters/creator"
-          },
-          {
-            "$ref": "#/components/parameters/dateFrom"
-          },
-          {
-            "$ref": "#/components/parameters/dateTo"
-          },
-          {
-            "$ref": "#/components/parameters/localTimeFrom"
-          },
-          {
-            "$ref": "#/components/parameters/localTimeTo"
-          },
-          {
-            "$ref": "#/components/parameters/embed"
-          },
-          {
-            "$ref": "#/components/parameters/embedCalendarSummaries"
-          },
-          {
-            "$ref": "#/components/parameters/embedUitpasPrices"
-          },
-          {
-            "$ref": "#/components/parameters/facets"
-          },
-          {
-            "$ref": "#/components/parameters/groupBy"
-          },
-          {
-            "$ref": "#/components/parameters/regions"
-          },
-          {
-            "$ref": "#/components/parameters/coordinates"
-          },
-          {
-            "$ref": "#/components/parameters/distance"
-          },
-          {
-            "$ref": "#/components/parameters/bounds"
-          },
-          {
-            "$ref": "#/components/parameters/id"
-          },
-          {
-            "$ref": "#/components/parameters/isDuplicate"
-          },
-          {
-            "$ref": "#/components/parameters/locationId"
-          },
-          {
-            "$ref": "#/components/parameters/organizerId"
-          },
-          {
-            "$ref": "#/components/parameters/labels"
-          },
-          {
-            "$ref": "#/components/parameters/locationLabels"
-          },
-          {
-            "$ref": "#/components/parameters/organizerLabels"
-          },
-          {
-            "$ref": "#/components/parameters/mainLanguage"
-          },
-          {
-            "$ref": "#/components/parameters/languages"
-          },
-          {
-            "$ref": "#/components/parameters/completedLanguages"
-          },
-          {
-            "$ref": "#/components/parameters/hasMediaObjects"
-          },
-          {
-            "$ref": "#/components/parameters/price"
-          },
-          {
-            "$ref": "#/components/parameters/minPrice"
-          },
-          {
-            "$ref": "#/components/parameters/maxPrice"
-          },
-          {
-            "$ref": "#/components/parameters/sortScore"
-          },
-          {
-            "$ref": "#/components/parameters/sortAvailableTo"
-          },
-          {
-            "$ref": "#/components/parameters/sortCreated"
-          },
-          {
-            "$ref": "#/components/parameters/sortModified"
-          },
-          {
-            "$ref": "#/components/parameters/sortDistance"
-          },
-          {
-            "$ref": "#/components/parameters/status"
-          },
-          {
-            "$ref": "#/components/parameters/termIds"
-          },
-          {
-            "$ref": "#/components/parameters/uitpas"
-          },
-          {
-            "$ref": "#/components/parameters/hasVideos"
-          },
-          {
-            "$ref": "#/components/parameters/workflowStatusOffer"
-          }
-        ]
-      },
-      "parameters": [],
-            "security":[
-        {
-          "CLIENT_IDENTIFICATION":[]
-        },
-        {
-          "CLIENT_ACCESS_TOKEN":[]
-        },
-        {
-          "USER_ACCESS_TOKEN":[]
         }
-        ],
-    "/organizers": {
-      "get": {
-        "summary": "Search organizers",
-        "tags": [
-          "Organizers"
-        ],
-        "responses": {
-          "200": {
-            "description": "A single page of search results. If `?embed=true` is used, the search results will contain the complete JSON details. Otherwise only `@id` and `@type` will be returned.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "itemsPerPage": {
-                      "type": "integer",
-                      "example": 30,
-                      "description": "The amount of results that is being returned per page."
-                    },
-                    "totalItems": {
-                      "type": "integer",
-                      "example": 2345,
-                      "description": "Total amount of results for the given query parameters."
-                    },
-                    "member": {
-                      "type": "array",
-                      "description": "Search results (paginated). Note that the complete search results details will only be returned if `?embed=true` is used. Otherwise only the `@id` will be returned.",
-                      "items": {
-                        "$ref": "../models/organizer.json"
-                      }
-                    },
-                    "facet": {
-                      "type": "object",
-                      "description": "Facet counts per possible filter & value.",
-                      "properties": {
-                        "regions": {
-                          "$ref": "../models/common-facets.json"
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "itemsPerPage",
-                    "totalItems",
-                    "member"
-                  ]
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "itemsPerPage": 20,
-                      "totalItems": 3,
-                      "member": [
-                        {
-                          "@id": "https://io-test.uitdatabank.be/organizer/7dc08012-488b-4e2b-b318-625d9bce03d7",
-                          "@type": "Organizer"
-                        },
-                        {
-                          "@id": "https://io-test.uitdatabank.be/organizer/c683ddfe-4ff9-4b4b-a198-b9f553cfc479",
-                          "@type": "Organizer"
-                        },
-                        {
-                          "@id": "https://io-test.uitdatabank.be/organizer/15d5de07-57e6-4015-84c6-e9c94ccfd9ef",
-                          "@type": "Organizer"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        },
-        "operationId": "get-organizers",
-        "description": "Returns a paginated list of organizers that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/x-client-id"
-          },
-          {
-            "$ref": "#/components/parameters/x-api-key"
-          },
-          {
-            "$ref": "#/components/parameters/q"
-          },
-          {
-            "$ref": "#/components/parameters/name"
-          },
-          {
-            "$ref": "#/components/parameters/website"
-          },
-          {
-            "$ref": "#/components/parameters/id"
-          },
-          {
-            "$ref": "#/components/parameters/domain"
-          },
-          {
-            "$ref": "#/components/parameters/postalCode"
-          },
-          {
-            "$ref": "#/components/parameters/addressCountry"
-          },
-          {
-            "$ref": "#/components/parameters/creator"
-          },
-          {
-            "$ref": "#/components/parameters/contributors"
-          },
-          {
-            "$ref": "#/components/parameters/facets"
-          },
-          {
-            "$ref": "#/components/parameters/regions"
-          },
-          {
-            "$ref": "#/components/parameters/coordinates"
-          },
-          {
-            "$ref": "#/components/parameters/embed"
-          },
-          {
-            "$ref": "#/components/parameters/distance"
-          },
-          {
-            "$ref": "#/components/parameters/bounds"
-          },
-          {
-            "$ref": "#/components/parameters/labels"
-          },
-          {
-            "$ref": "#/components/parameters/hasImages"
-          },
-          {
-            "$ref": "#/components/parameters/workflowStatusOrganizer"
-          },
-          {
-            "$ref": "#/components/parameters/sortScore"
-          },
-          {
-            "$ref": "#/components/parameters/sortCreated"
-          },
-          {
-            "$ref": "#/components/parameters/sortModified"
-          }
-        ]
-      },
-      "parameters": [],
-      "security":[
-        {
-          "CLIENT_IDENTIFICATION":[]
-        },
-        {
-          "CLIENT_ACCESS_TOKEN":[]
-        },
-        {
-          "USER_ACCESS_TOKEN":[]
-        }
-        ],
-    "/places": {
-      "get": {
-        "summary": "Search places",
-        "tags": [
-          "Events & places"
-        ],
-        "responses": {
-          "200": {
-            "description": "A single page of search results. If `?embed=true` is used, the search results will contain the complete JSON details. Otherwise only `@id` and `@type` will be returned.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "itemsPerPage": {
-                      "type": "integer",
-                      "example": 30,
-                      "description": "The amount of results that is being returned per page."
-                    },
-                    "totalItems": {
-                      "type": "integer",
-                      "example": 2345,
-                      "description": "Total amount of results for the given query parameters."
-                    },
-                    "member": {
-                      "type": "array",
-                      "description": "Search results (paginated). Note that the complete search results details will only be returned if `?embed=true` is used. Otherwise only the `@id` will be returned.",
-                      "items": {
-                        "$ref": "../models/place.json"
-                      }
-                    },
-                    "facet": {
-                      "type": "object",
-                      "description": "Facet counts per possible filter & value.",
-                      "properties": {
-                        "regions": {
-                          "$ref": "../models/common-facets.json"
-                        },
-                        "types": {
-                          "$ref": "../models/common-facets.json"
-                        },
-                        "themes": {
-                          "$ref": "../models/common-facets.json"
-                        },
-                        "facilities": {
-                          "$ref": "../models/common-facets.json"
-                        },
-                        "labels": {
-                          "$ref": "../models/common-facets.json"
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "itemsPerPage",
-                    "totalItems",
-                    "member"
-                  ]
-                },
-                "examples": {
-                  "Example": {
-                    "value": {
-                      "itemsPerPage": 20,
-                      "totalItems": 3,
-                      "member": [
-                        {
-                          "@id": "https://io-test.uitdatabank.be/place/7dc08012-488b-4e2b-b318-625d9bce03d7",
-                          "@type": "Place"
-                        },
-                        {
-                          "@id": "https://io-test.uitdatabank.be/place/c683ddfe-4ff9-4b4b-a198-b9f553cfc479",
-                          "@type": "Place"
-                        },
-                        {
-                          "@id": "https://io-test.uitdatabank.be/place/15d5de07-57e6-4015-84c6-e9c94ccfd9ef",
-                          "@type": "Place"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        },
-        "operationId": "get-places",
-        "description": "Returns a paginated list of places that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.\n\nAdd `embedCalendarSummaries` to have an extra property `calendarSummary` in the results that contains one or more formatted human-readable summaries of the date/time info of the result. See <a href=\"search-api/calendar-summaries\">the guide about embedding the calendar summaries</a> for more details.\n",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/x-client-id"
-          },
-          {
-            "$ref": "#/components/parameters/x-api-key"
-          },
-          {
-            "$ref": "#/components/parameters/text"
-          },
-          {
-            "$ref": "#/components/parameters/q"
-          },
-          {
-            "$ref": "#/components/parameters/postalCode"
-          },
-          {
-            "$ref": "#/components/parameters/addressCountry"
-          },
-          {
-            "$ref": "#/components/parameters/maxAge"
-          },
-          {
-            "$ref": "#/components/parameters/minAge"
-          },
-          {
-            "$ref": "#/components/parameters/allAges"
-          },
-          {
-            "$ref": "#/components/parameters/audienceType"
-          },
-          {
-            "$ref": "#/components/parameters/availableFrom"
-          },
-          {
-            "$ref": "#/components/parameters/availableTo"
-          },
-          {
-            "$ref": "#/components/parameters/attendanceMode"
-          },
-          {
-            "$ref": "#/components/parameters/bookingAvailability"
-          },
-          {
-            "$ref": "#/components/parameters/calendarType"
-          },
-          {
-            "$ref": "#/components/parameters/createdFrom"
-          },
-          {
-            "$ref": "#/components/parameters/createdTo"
-          },
-          {
-            "$ref": "#/components/parameters/embed"
-          },
-          {
-            "$ref": "#/components/parameters/embedCalendarSummaries"
-          },
-          {
-            "$ref": "#/components/parameters/embedUitpasPrices"
-          },
-          {
-            "$ref": "#/components/parameters/modifiedFrom"
-          },
-          {
-            "$ref": "#/components/parameters/modifiedTo"
-          },
-          {
-            "$ref": "#/components/parameters/contributors"
-          },
-          {
-            "$ref": "#/components/parameters/creator"
-          },
-          {
-            "$ref": "#/components/parameters/dateFrom"
-          },
-          {
-            "$ref": "#/components/parameters/dateTo"
-          },
-          {
-            "$ref": "#/components/parameters/localTimeFrom"
-          },
-          {
-            "$ref": "#/components/parameters/localTimeTo"
-          },
-          {
-            "$ref": "#/components/parameters/facets"
-          },
-          {
-            "$ref": "#/components/parameters/groupBy"
-          },
-          {
-            "$ref": "#/components/parameters/regions"
-          },
-          {
-            "$ref": "#/components/parameters/coordinates"
-          },
-          {
-            "$ref": "#/components/parameters/distance"
-          },
-          {
-            "$ref": "#/components/parameters/bounds"
-          },
-          {
-            "$ref": "#/components/parameters/id"
-          },
-          {
-            "$ref": "#/components/parameters/isDuplicate"
-          },
-          {
-            "$ref": "#/components/parameters/locationId"
-          },
-          {
-            "$ref": "#/components/parameters/organizerId"
-          },
-          {
-            "$ref": "#/components/parameters/labels"
-          },
-          {
-            "$ref": "#/components/parameters/organizerLabels"
-          },
-          {
-            "$ref": "#/components/parameters/mainLanguage"
-          },
-          {
-            "$ref": "#/components/parameters/languages"
-          },
-          {
-            "$ref": "#/components/parameters/completedLanguages"
-          },
-          {
-            "$ref": "#/components/parameters/hasMediaObjects"
-          },
-          {
-            "$ref": "#/components/parameters/price"
-          },
-          {
-            "$ref": "#/components/parameters/minPrice"
-          },
-          {
-            "$ref": "#/components/parameters/maxPrice"
-          },
-          {
-            "$ref": "#/components/parameters/sortScore"
-          },
-          {
-            "$ref": "#/components/parameters/sortAvailableTo"
-          },
-          {
-            "$ref": "#/components/parameters/sortCreated"
-          },
-          {
-            "$ref": "#/components/parameters/sortModified"
-          },
-          {
-            "$ref": "#/components/parameters/sortDistance"
-          },
-          {
-            "$ref": "#/components/parameters/status"
-          },
-          {
-            "$ref": "#/components/parameters/termIds"
-          },
-          {
-            "$ref": "#/components/parameters/uitpas"
-          },
-          {
-            "$ref": "#/components/parameters/hasVideos"
-          },
-          {
-            "$ref": "#/components/parameters/workflowStatusOffer"
-          }
-        ]
-      },
-      "parameters": [],
     }
-  },
-  "tags": [
-    {
-      "name": "Events & places"
-    },
-    {
-      "name": "Organizers"
-    }
-  ],
-  "components": {
-    "securitySchemes": {},
-    "schemas": {
-      "Error": {
-        "$ref": "https://raw.githubusercontent.com/cultuurnet/apidocs/main/projects/errors/models/Error.json",
-        "x-internal": true
-      }
-    },
-    "parameters": {
-      "x-client-id": {
-        "schema": {
-          "type": "string"
-        },
-        "in": "header",
-        "name": "x-client-id",
-        "description": "The client id of your project (if not using an API key). May also be replaced with a `clientId` query parameter."
-      },
-      "x-api-key": {
-        "schema": {
-          "type": "string"
-        },
-        "in": "header",
-        "name": "x-api-key",
-        "description": "The API key of your project on https://projectaanvraag.uitdatabank.be (if not using a client id). May also be replaced with an `apiKey` query parameter. Will be deprecated in favour of `x-client-id` in the future, but will still be supported.",
-        "deprecated": true
-      },
-      "text": {
-        "schema": {
-          "type": "string",
-          "example": " dijle (wandelen OR fietsen)"
-        },
-        "in": "query",
-        "name": "text",
-        "description": "Free text search terms. Returns results that match all or some of the given terms. May contain `AND` and `OR` operators, and brackets for grouping. Can not filter on specific fields (contrary to the `q` parameter). Typically used to search on user-provided keywords."
-      },
-      "q": {
-        "schema": {
-          "type": "string",
-          "example": "labels:\"ook voor kinderen\" OR labels:\"ook voor jongeren\""
-        },
-        "in": "query",
-        "name": "q",
-        "description": "An advanced query in Lucene syntax, allowing you to construct complex AND/OR filters on specific fields."
-      },
-      "contributors": {
-        "schema": {
-          "format": "email",
-          "type": "string",
-          "example": "technical-support@publiq.be"
-        },
-        "in": "query",
-        "name": "contributors",
-        "description": "Returns results for which a particular user / email address is a contributor"
-      },
-      "name": {
-        "schema": {
-          "type": "string",
-          "example": "publiq"
-        },
-        "in": "query",
-        "name": "name",
-        "description": "Returns only results whose name autocompletes on the given name. For example searching for `pub` will return matches with `publiq` in the name."
-      },
-      "website": {
-        "schema": {
-          "type": "string",
-          "example": "https://www.publiq.be/example"
-        },
-        "in": "query",
-        "name": "website",
-        "description": "Returns only results that have the given URL as their website. URLs in the query parameter and on the search results are normalized to reduce false negatives."
-      },
-      "domain": {
-        "schema": {
-          "type": "string",
-          "example": "www.publiq.be"
-        },
-        "in": "query",
-        "name": "domain",
-        "description": "Returns only results that have a website on the given domain. Domains in the query parameter and on the search results are normalized to reduce false negatives."
-      },
-      "postalCode": {
-        "schema": {
-          "type": "string",
-          "example": "1000"
-        },
-        "in": "query",
-        "name": "postalCode",
-        "description": "Returns only results that have the exact same postal code in their address. Typically 4 digits for Belgian addresses but can also be a different format for international addresses."
-      },
-      "isDuplicate": {
-        "schema": {
-          "type": "boolean"
-        },
-        "in": "query",
-        "name": "isDuplicate",
-        "description": "Returns only results that include or excludes duplicate places"
-      },
-      "embed": {
-        "schema": {
-          "type": "boolean"
-        },
-        "in": "query",
-        "name": "embed",
-        "description": "Returns the results with the actual JSON bodies of the individual items"
-      },
-      "embedUitpasPrices": {
-        "schema": {
-          "type": "boolean"
-        },
-        "in": "query",
-        "name": "embedUitpasPrices",
-        "description": "Returns the results with the UiTPAS prices included (if applicable)"
-      },
-      "addressCountry": {
-        "schema": {
-          "type": "string",
-          "example": "BE",
-          "pattern": "^[A-Z][A-Z]$",
-          "default": "BE"
-        },
-        "in": "query",
-        "name": "addressCountry",
-        "description": "Returns only results that have the exact same country code in their address. Formatted as an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. The default value can be disabled by setting the value to `*` or by using the `disableDefaultFilters` query parameter."
-      },
-      "maxAge": {
-        "schema": {
-          "type": "integer",
-          "example": 18
-        },
-        "in": "query",
-        "name": "maxAge",
-        "description": "Returns only results that are targeted to participants/visitors of at most the given age (in years). The given age will be included in results."
-      },
-      "minAge": {
-        "schema": {
-          "type": "integer",
-          "example": 12
-        },
-        "in": "query",
-        "name": "minAge",
-        "description": "Returns only results that are targeted to participants/visitors of at least the given age (in years). The given age will be included in results."
-      },
-      "allAges": {
-        "schema": {
-          "type": "boolean"
-        },
-        "in": "query",
-        "name": "allAges",
-        "description": "Returns only results that are suitable for participants/visitors of all ages if set to `true`, or only returns results that are suitable for a specific age group if set to `false`."
-      },
-      "audienceType": {
-        "schema": {
-          "type": "string",
-          "enum": [
-            "everyone",
-            "members",
-            "education"
-          ],
-          "default": "everyone"
-        },
-        "in": "query",
-        "name": "audienceType",
-        "description": "Returns only results with the given enum value as their targeted audience. Results with audienceType `everyone` are targeted to any participant/visitor. Results with audienceType `members` are only targeted towards members of the organizer of the event. Results with audienceType `education` are targeted towards [CultuurKuur](https://www.cultuurkuur.be/)."
-      },
-      "availableFrom": {
-        "schema": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2022-03-04T10:30:00+01:00"
-        },
-        "in": "query",
-        "name": "availableFrom",
-        "description": "Returns only results that should (still) be visible on online calendars after the given date-time. Defaults to the current date-time of the request. The default value can be disabled by setting the value to `*` or by using the `disableDefaultFilters` query parameter. See (the guide about default filters)[../docs/search-api/common-filters/default-filters.md] for more information."
-      },
-      "availableTo": {
-        "schema": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2022-03-05T10:30:00+01:00"
-        },
-        "in": "query",
-        "name": "availableTo",
-        "description": "Returns only results that should be visible on online calendars up until the given date-time. Defaults to the current date-time of the request. The default value can be disabled by setting the value to `*` or by using the `disableDefaultFilters` query parameter. See (the guide about default filters)[../docs/search-api/common-filters/default-filters.md] for more information."
-      },
-      "attendanceMode": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "online",
-              "offline",
-              "mixed"
-            ]
-          }
-        },
-        "in": "query",
-        "name": "attendanceMode",
-        "description": "Returns only results with the given enum value as their attendance mode. Results with attendanceMode `online` are only happening online (e.g. via a video stream). Results with attendanceMode `offline` are only happening on a physical location. Results with attendanceMode `mixed` can be attended both online or offline. Note that when filtering on `mixed`, _only_ results that are both happening online and offline will be included. Accepts multiple comma-separated values to return results that have one of the given attendance modes.",
-        "style": "form",
-        "explode": false
-      },
-      "bookingAvailability": {
-        "schema": {
-          "type": "string",
-          "enum": [
-            "Available",
-            "Unavailable"
-          ]
-        },
-        "in": "query",
-        "name": "bookingAvailability",
-        "description": "Returns only results with the given enum value as their bookingAvailability type. Results with bookingAvailability `Available` still have tickets/reservations available. Results with bookingAvailability `Unavailable` are sold out / fully booked."
-      },
-      "calendarType": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "single",
-              "multiple",
-              "periodic",
-              "permanent"
-            ]
-          }
-        },
-        "style": "form",
-        "explode": false,
-        "in": "query",
-        "name": "calendarType",
-        "description": "Returns only results with the given enum value as their calendarType. Accepts multiple comma-separated values to return results that have one of the given calendar types. [Here is a detailed guide](./entry-api/shared/calendar-info#calendartype) with more information."
-      },
-      "createdFrom": {
-        "schema": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2022-03-04T10:30:00+01:00"
-        },
-        "in": "query",
-        "name": "createdFrom",
-        "description": "Returns only results that were created at or after the given date-time."
-      },
-      "createdTo": {
-        "schema": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2022-03-05T10:30:00+01:00"
-        },
-        "in": "query",
-        "name": "createdTo",
-        "description": "Returns only results that were created at or before the given date-time."
-      },
-      "modifiedFrom": {
-        "schema": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2022-03-04T10:30:00+01:00"
-        },
-        "in": "query",
-        "name": "modifiedFrom",
-        "description": "Returns only results that were last modified at or after the given date-time. If the result has never been modified, the `created` date-time will be used as `modified` instead."
-      },
-      "modifiedTo": {
-        "schema": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2022-03-05T10:30:00+01:00"
-        },
-        "in": "query",
-        "name": "modifiedTo",
-        "description": "Returns only results that were last modified at or before the given date-time. If the result has never been modified, the `created` date-time will be used as `modified` instead."
-      },
-      "creator": {
-        "schema": {
-          "type": "string",
-          "example": "lxBfdgJwUaJUgm7CBCeKF2eE2fnsyLCB@clients"
-        },
-        "in": "query",
-        "name": "creator",
-        "description": "Returns only results that have a creator with the given user identifier. Due to historic reasons and evolutions in the id management systems, a user identifier can be one of: a UUID (for creators that had an UiTiD v1), an Auth0 user id (for new UiTiD v2 creators), or in some very old cases even an email address or nickname. (No new events or places are created with an email address or nickname as creator.) Can also be a client id suffixed with `@clients` in the case of results created with a client access token instead of a user access token."
-      },
-      "dateFrom": {
-        "schema": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2022-03-04T10:30:00+01:00"
-        },
-        "in": "query",
-        "name": "dateFrom",
-        "description": "Returns only events that are happening at some point after the given date-time, and places that are open at some point after the given date-time. Permanent events or places are always returned by this parameter."
-      },
-      "dateTo": {
-        "schema": {
-          "type": "string",
-          "format": "date-time",
-          "example": "2022-03-05T10:30:00+01:00"
-        },
-        "in": "query",
-        "name": "dateTo",
-        "description": "Returns only events that are happening at some point before the given date-time, and places that are open at some point before the given date-time. Permanent events or places are always returned by this parameter."
-      },
-      "localTimeFrom": {
-        "schema": {
-          "type": "string",
-          "pattern": "^([01]\\d|2[0123]):([012345]\\d)$",
-          "example": "08:30"
-        },
-        "in": "query",
-        "name": "localTimeFrom",
-        "description": "Returns only events that are happening at some point after the given time, and places that are open at some point after the given time. Dates and timezones are not taken into account by this parameter. Permanent events or places are always returned by this parameter."
-      },
-      "localTimeTo": {
-        "schema": {
-          "type": "string",
-          "pattern": "^([01]\\d|2[0123]):([012345]\\d)$",
-          "example": "23:59"
-        },
-        "in": "query",
-        "name": "localTimeTo",
-        "description": "Returns only events that are happening at some point before the given time, and places that are open at some point before the given time. Dates and timezones are not taken into account by this parameter. Permanent events or places are always returned by this parameter."
-      },
-      "embedCalendarSummaries": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "xs-text",
-              "sm-text",
-              "md-text",
-              "lg-text",
-              "xs-html",
-              "sm-html",
-              "md-html",
-              "lg-html"
-            ]
-          }
-        },
-        "in": "query",
-        "name": "embedCalendarSummaries[]",
-        "description": "Adds an extra `calendarSummary` property to the results that contains one or more formatted human-readable summaries of the date/time info of the result. May be repeated to include multiple summaries per result. See the operation's description above for more info on how to repeat parameters.",
-        "style": "form",
-        "explode": true
-      },
-      "facets": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "regions",
-              "types",
-              "themes",
-              "facilities",
-              "labels"
-            ]
-          }
-        },
-        "in": "query",
-        "name": "facets[]",
-        "description": "Adds an extra `facet` property in the response with possible values for a given filter, and a prediction of the total results if applied. May be repeated to include facet counts for multiple filters. See the operation's description above for more info on how to repeat parameters. See (the guide about facets)[../docs/search-api/advanced/facets.md] for more information.",
-        "style": "form",
-        "explode": true
-      },
-      "regions": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "in": "query",
-        "name": "regions[]",
-        "description": "Returns only results that are geographically located in the given region. Regions may be fetched programmatically from [https://search.uitdatabank.be/autocomplete.json](https://search.uitdatabank.be/autocomplete.json).",
-        "style": "form",
-        "explode": true
-      },
-      "coordinates": {
-        "schema": {
-          "type": "string",
-          "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$",
-          "example": "50.8511740,4.338674"
-        },
-        "in": "query",
-        "name": "coordinates",
-        "description": "A pair of latitude and longitude coordinates to find results that are located within a distance of the given geographical point. Must be used in combination with the `distance` parameter."
-      },
-      "distance": {
-        "schema": {
-          "type": "string",
-          "pattern": "^\\s*(\\d+\\.?\\d*)\\s*(mi|miles|yd|yards|ft|feet|in|inch|km|kilometers|m|meters|cm|centimeters|mm|millimeters|NM|nmi|nauticalmiles)\\s*$",
-          "example": "10km"
-        },
-        "in": "query",
-        "name": "distance",
-        "description": "Returns only results that are geographically located within the given distance from the `coordinates` parameter."
-      },
-      "bounds": {
-        "schema": {
-          "type": "string",
-          "example": "34.172684,-118.604794|34.236144,-118.500938",
-          "pattern": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)\\|[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
-        },
-        "in": "query",
-        "name": "bounds",
-        "description": "Returns only results that are located in a specific geographical area defined by a pair of south-west coordinates and north-east coordinates. The two pairs of coordinates are separated by a pipe character (`|`)."
-      },
-      "groupBy": {
-        "schema": {
-          "type": "string",
-          "enum": [
-            "productionId"
-          ]
-        },
-        "in": "query",
-        "name": "groupBy",
-        "description": "Groups the results by their production. Grouping by productions ensures that for every production, only 1 event is returned in the search results"
-      },
-      "id": {
-        "schema": {
-          "type": "string",
-          "example": "f29d2182-2db0-4f99-831a-8e6a64c1c9c1"
-        },
-        "in": "query",
-        "name": "id",
-        "description": "Returns only results that have the exact same id. An id can be extracted from an event, place, or organizer URI by taking all the characters after the last `/`. For example for the URI `https://io.uitdatabank.be/event/75573a64-ddc8-4fd0-8b07-d258939dd74f` the id is `75573a64-ddc8-4fd0-8b07-d258939dd74f`. Note that while it will be a UUID in most cases, it is not guaranteed to always be one!"
-      },
-      "locationId": {
-        "schema": {
-          "type": "string",
-          "example": "a0368d10-ded0-4925-b94a-2835f73e255e"
-        },
-        "in": "query",
-        "name": "locationId",
-        "description": "Returns only results that are related to the given location id (= place id). A place's id can be extracted from its URI by taking all the characters after the last `/`. For example for the URI `https://io.uitdatabank.be/place/75573a64-ddc8-4fd0-8b07-d258939dd74f` the id is `75573a64-ddc8-4fd0-8b07-d258939dd74f`. Note that while it will be a UUID in most cases, it is not guaranteed to always be one!"
-      },
-      "organizerId": {
-        "schema": {
-          "type": "string",
-          "example": "4fa5dddf-73d5-47f8-b54f-45d88cc1661a"
-        },
-        "in": "query",
-        "name": "organizerId",
-        "description": "Returns only results that are related to the given organizer id. An organizer's id can be extracted from its URI by taking all the characters after the last `/`. For example for the URI `https://io.uitdatabank.be/organizer/75573a64-ddc8-4fd0-8b07-d258939dd74f` the id is `75573a64-ddc8-4fd0-8b07-d258939dd74f`. Note that while it will be a UUID in most cases, it is not guaranteed to always be one!"
-      },
-      "labels": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "in": "query",
-        "name": "labels[]",
-        "style": "form",
-        "description": "Returns only results that have the given label(s) in either their `labels` or `hiddenLabels` properties. May be repeated to only return results that have all the given labels. See the operation's description above for more info on how to repeat parameters.",
-        "explode": true
-      },
-      "locationLabels": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "in": "query",
-        "name": "locationLabels[]",
-        "style": "form",
-        "description": "Returns only results that have the given label(s) in their location's `labels` or `hiddenLabels` properties. May be repeated to only return results with a location that has all the given labels. See the operation's description above for more info on how to repeat parameters.",
-        "explode": true
-      },
-      "organizerLabels": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "in": "query",
-        "name": "organizerLabels[]",
-        "style": "form",
-        "description": "Returns only results that have the given label(s) in their organizer's `labels` or `hiddenLabels` properties. May be repeated to only return results with an organizer that has all the given labels. See the operation's description above for more info on how to repeat parameters.",
-        "explode": true
-      },
-      "mainLanguage": {
-        "schema": {
-          "type": "string",
-          "pattern": "^[a-z][a-z]$",
-          "enum": [
-            "nl",
-            "fr",
-            "de",
-            "en"
-          ]
-        },
-        "in": "query",
-        "name": "mainLanguage",
-        "description": "Returns only results that have the given language code as their main (= original) language."
-      },
-      "languages": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^[a-z][a-z]$",
-            "enum": [
-              "nl",
-              "fr",
-              "de",
-              "en"
-            ]
-          }
-        },
-        "in": "query",
-        "name": "languages[]",
-        "style": "form",
-        "description": "Returns only results that have a localised value in the given language for one or more translatable fields like `name`. May be repeated to only return results that have localised values for all the given languages. See the operation's description above for more info on how to repeat parameters.",
-        "explode": true
-      },
-      "completedLanguages": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^[a-z][a-z]$",
-            "enum": [
-              "nl",
-              "fr",
-              "de",
-              "en"
-            ]
-          }
-        },
-        "in": "query",
-        "name": "completedLanguages[]",
-        "style": "form",
-        "description": "Returns only results that have a localised value in the given language for every translatable field. May be repeated to only return results that have localised values for all the given languages. See the operation's description above for more info on how to repeat parameters.",
-        "explode": true
-      },
-      "hasMediaObjects": {
-        "schema": {
-          "type": "boolean"
-        },
-        "in": "query",
-        "name": "hasMediaObjects",
-        "description": "Returns only results that have one or more items inside their `mediaObject` property if set to `true`. Returns only results without `mediaObject` property if set to `false`."
-      },
-      "hasImages": {
-        "schema": {
-          "type": "boolean"
-        },
-        "in": "query",
-        "name": "hasImages",
-        "description": "Returns only results that have one or more items inside their `images` property if set to `true`. Returns only results without `images` property if set to `false`."
-      },
-      "price": {
-        "schema": {
-          "type": "number",
-          "example": 5.75
-        },
-        "in": "query",
-        "name": "price",
-        "description": "Returns only results with exactly the same price for the base tariff (in EUR)."
-      },
-      "minPrice": {
-        "schema": {
-          "type": "number",
-          "example": 5.75
-        },
-        "in": "query",
-        "name": "minPrice",
-        "description": "Returns only results with a price for the base tariff that is equal to or higher than the given price (in EUR)."
-      },
-      "maxPrice": {
-        "schema": {
-          "type": "number"
-        },
-        "in": "query",
-        "name": "maxPrice",
-        "description": "Returns only results with a price for the base tariff that is equal to or lower than the given price (in EUR)."
-      },
-      "sortScore": {
-        "schema": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ]
-        },
-        "in": "query",
-        "name": "sort[score]",
-        "description": "Sorts the results by their score (relevance), either with the lowest score first (`asc`) or the highest score first (`desc`). See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
-      },
-      "sortAvailableTo": {
-        "schema": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ]
-        },
-        "in": "query",
-        "name": "sort[availableTo]",
-        "description": "Sorts the results by their `availableTo` date-time, either with the oldest date-time first (`asc`) or the highest date-time first (`desc`). Most commonly used to show events and/or places that will end or become unavailable soon. See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
-      },
-      "sortCreated": {
-        "schema": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ]
-        },
-        "in": "query",
-        "name": "sort[created]",
-        "description": "Sorts the results by their `created` date-time, either with the oldest results first (`asc`) or the newest results first (`desc`). See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
-      },
-      "sortModified": {
-        "schema": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ]
-        },
-        "in": "query",
-        "name": "sort[modified]",
-        "description": "Sorts the results by their `modified` date-time, either with the least recently modified results first (`asc`) or the most recently modified results first (`desc`). See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
-      },
-      "sortDistance": {
-        "schema": {
-          "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ]
-        },
-        "in": "query",
-        "name": "sort[distance]",
-        "description": "Sorts the results by their distance from the `coordinates` parameter. Can only be used if `coordinates` and `distance` are also set. You may use multiple sort parameters. See (the guide about sorting)[../docs/search-api/sorting.md] for more information."
-      },
-      "status": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Available",
-              "TemporarilyUnavailable",
-              "Unavailable"
-            ]
-          }
-        },
-        "in": "query",
-        "style": "form",
-        "explode": false,
-        "name": "status",
-        "description": "Returns only results with exactly the same status type as the given enum value. `Available` means an event is happening as planned, and a place can be visited during its normal opening hours. `TemporarilyUnavailable` means an event has been postponed to a later date (yet to be determined), and a place is temporarily closed (for example due to renovations). `Unavailable` means an event is cancelled, or a place is permanently closed. If combined with `dateFrom` and/or `dateTo`, only results that have the given status in that time period will be returned. Accepts multiple comma-separated values to return results that have one of the given status types."
-      },
-      "termIds": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "in": "query",
-        "name": "termIds[]",
-        "style": "form",
-        "description": "Returns only results that have the given term id(s) in either their `terms` property items. May be repeated to only return results that have all the given term ids. See the operation's description above for more info on how to repeat parameters.",
-        "explode": true
-      },
-      "uitpas": {
-        "schema": {
-          "type": "boolean"
-        },
-        "in": "query",
-        "name": "uitpas",
-        "description": "Returns only results that are related to UiTPAS if set to `true`. Returns only results that are not related to UiTPAS if set to `false`."
-      },
-      "hasVideos": {
-        "schema": {
-          "type": "boolean"
-        },
-        "in": "query",
-        "name": "hasVideos",
-        "description": "Returns only results that have one or more items in their `videos` property if set to `true`. Returns only results that have no `videos` property if set to `false`."
-      },
-      "workflowStatusOffer": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "READY_FOR_VALIDATION",
-              "APPROVED",
-              "REJECTED",
-              "DELETED",
-              "*"
-            ],
-            "example": "DRAFT"
-          }
-        },
-        "style": "form",
-        "explode": false,
-        "in": "query",
-        "name": "workflowStatus",
-        "description": "Returns only results with exactly the same workflow status as the given enum value. Accepts multiple comma-separated values to return results that have one of the given workflow statuses. Defaults to only return results that either have the workflow status `READY_FOR_VALIDATION` or `APPROVED`. The default value can be reset by setting the parameter to `*`. See (the guide about default filters)[../docs/search-api/common-filters/default-filters.md] for more information."
-      },
-      "workflowStatusOrganizer": {
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "ACTIVE",
-              "DELETED",
-              "*"
-            ],
-            "example": "ACTIVE"
-          }
-        },
-        "style": "form",
-        "explode": false,
-        "in": "query",
-        "name": "workflowStatus",
-        "description": "Returns only results with exactly the same workflow status as the given enum value. Accepts multiple comma-separated values to return results that have one of the given workflow statuses. Defaults to only return results that have the workflow status `ACTIVE`. The default value can be reset by setting the parameter to `*`. See (the guide about default filters)[../docs/search-api/common-filters/default-filters.md] for more information."
-      }
-    },
-    "responses": {
-      "Unauthorized": {
-        "description": "Unauthorized. Your request is missing the required credentials to authenticate. See the Authentication documentation for more info.\n\n* type: https://api.publiq.be/probs/auth/unauthorized\n* detail: might contain a developer-readable explanation of the reason",
-        "content": {
-          "application/problem+json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "examples": {
-              "Example": {
-                "value": {
-                  "type": "https://api.publiq.be/probs/auth/unauthorized",
-                  "title": "Unauthorized",
-                  "status": 401
-                }
-              }
-            }
-          }
-        }
-      },
-      "Forbidden": {
-        "description": "Forbidden. Your request was successfully authenticated but you do not have permission to perform this particular request.\n\n* type: https://api.publiq.be/probs/auth/forbidden\n* detail: might contain a developer-readable explanation of the reason",
-        "content": {
-          "application/problem+json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "examples": {
-              "Example": {
-                "value": {
-                  "type": "https://api.publiq.be/probs/auth/forbidden",
-                  "title": "Forbidden",
-                  "status": 403,
-                  "detail": "user must be admin of organizer abcd1234"
-                }
-              }
-            }
-          }
-        }
-      },
-      "NotFound": {
-        "description": "The requested resource (URL) could not be found.\nThis can be due to one of multiple reasons:\n\n* The endpoint has a typo and/or does not exist on the API\n* One of the path parameters contains a value that is invalid or does not exist\n* One of the required query parameters is missing\n* One of the query parameters has an invalid value\n\nThe `detail` property of the response should contain more specific information.\n\nThe `type` will always be `https://api.publiq.be/probs/url/not-found`.",
-        "content": {
-          "application/problem+json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "examples": {
-              "Example": {
-                "value": {
-                  "type": "https://api.publiq.be/probs/url/not-found",
-                  "title": "URL not found",
-                  "status": 404,
-                  "detail": "The resource with id \"76C6AC08-763C-492E-A68C-CBC43A857229\" was not found."
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
### Added
- Security sections for Search API, so that an integrators knows which authentication methods (s)he can use for requesting data

![image](https://github.com/cultuurnet/apidocs/assets/29090370/ed3adc4b-29a9-4d4e-8b93-aee2694bbfc2)

---

Ticket: https://jira.publiq.be/browse/III-5876
