### PR TITLE
Remove incorrect sentence about the `workflowStatus` parameter

### DIFF
--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -674,7 +674,7 @@
           }
         },
         "operationId": "get-organizers",
-        "description": "Returns a paginated list of organizers that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n\nOther `array[string]` parameters without the `[]` suffix support multiple comma-separated values for `OR` filtering. For example:\n\n*  `?workflowStatus=DRAFT` to return all results with the draft workflow status.\n*  `?workflowStatus=REJECTED,DELETED` to return results with the rejected or deleted workflow status.",
+        "description": "Returns a paginated list of organizers that match the given filters.\n\n### Repeating query parameters\n\nParameters that have the type `array[string]` and `[]` as a suffix in their name in the list of query parameters below can be repeated to filter on multiple values with an `AND` operator. For example:\n\n*  `?labels[]=uitpas` to only include results that have the label `uitpas`\n*  `?labels[]=uitpas&labels[]=paspartoe` to only include results that have both the labels `uitpas` and `paspartoe`\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/x-client-id"


### PR DESCRIPTION
### Removed
- Incorrect sentence about the `worfklowStatus` parameter being applicable on the /organizers endpoint

You can check the output here now: https://docs.publiq.be/docs/uitdatabank/branches/uitdatabank%2Ffix-search-organizers/search-api/reference/operations/list-organizers