### PR TITLE
III-4601 - Added 409 status to Places

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,4 +283,4 @@ Follow these steps to troubleshoot any issues:
 
 While not required, you can use the following links to help you write excellent documentation:
 
-* <https://hemingwayapp.com/> for writing clearly by avoiding passive voice, long sentences, and so on.
+* hemingwayapp.com for writing clearly by avoiding passive voice, long sentences, and so on.

--- a/projects/uitdatabank/docs/errors.md
+++ b/projects/uitdatabank/docs/errors.md
@@ -104,24 +104,24 @@ The action you are trying to perform on an event cannot be done because the even
 
 When handling an image on an event / place / organizer, for example when making it the main image or when updating its `description` and/or `copyrightHolder`, the image id must be one of the images that are already linked to the event / place / organizer. Add the image first, so you can then perform the action on it.
 
-## image-must-be-linked-to-resource
+## duplicate-place
 
-* **Complete type:** `https://api.publiq.be/probs/uitdatabank/status-conflict`
-* **Title**: `Status conflict`
+* **Complete type:** `https://api.publiq.be/probs/uitdatabank/duplicate-place`
+* **Title**: `Duplicate place`
 * **Status**: `409`
 
 To ensure data integrity and avoid duplication within the system, each place must have a unique combination of the main language title and address. You get this error when (multiple) matches already exist in the system.
 You can use the attached query to get existing place(s).
 Subsequently, appropriate actions, such as updates to an existing Place, can be done to maintain uniqueness and coherence in UDB.
 
-*Example:*
-```
-    {
-        "query": "/place/581314d4-637e-407b-ba35-8b60847012d0",
-        "type": "https://api.publiq.be/probs/url/status-conflict",
-        "title": "Status conflict",
-        "status": 409,
-        "detail": "This place already exists. Use the attached query to get existing place(s) for the place you tried to create."
-    }
-```
+*Example single place returned:*
 
+```json
+{
+  "type": "https://api.publiq.be/probs/url/status-conflict",
+  "title": "Status conflict",
+  "status": 409,
+  "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes.",
+  "duplicatePlaceUrl": "/place/581314d4-637e-407b-ba35-8b60847012d0"
+}
+```

--- a/projects/uitdatabank/docs/errors.md
+++ b/projects/uitdatabank/docs/errors.md
@@ -103,3 +103,25 @@ The action you are trying to perform on an event cannot be done because the even
 * **Status**: `400`
 
 When handling an image on an event / place / organizer, for example when making it the main image or when updating its `description` and/or `copyrightHolder`, the image id must be one of the images that are already linked to the event / place / organizer. Add the image first, so you can then perform the action on it.
+
+## image-must-be-linked-to-resource
+
+* **Complete type:** `https://api.publiq.be/probs/uitdatabank/status-conflict`
+* **Title**: `Status conflict`
+* **Status**: `409`
+
+To ensure data integrity and avoid duplication within the system, each place must have a unique combination of the main language title and address. You get this error when (multiple) matches already exist in the system.
+You can use the attached query to get existing place(s).
+Subsequently, appropriate actions, such as updates to an existing Place, can be done to maintain uniqueness and coherence in UDB.
+
+*Example:*
+```
+    {
+        "query": "/place/581314d4-637e-407b-ba35-8b60847012d0",
+        "type": "https://api.publiq.be/probs/url/status-conflict",
+        "title": "Status conflict",
+        "status": 409,
+        "detail": "This place already exists. Use the attached query to get existing place(s) for the place you tried to create."
+    }
+```
+

--- a/projects/uitdatabank/docs/errors.md
+++ b/projects/uitdatabank/docs/errors.md
@@ -110,7 +110,7 @@ When handling an image on an event / place / organizer, for example when making 
 * **Title**: `Duplicate place`
 * **Status**: `409`
 
-To ensure data integrity and avoid duplication within the system, each place must have a unique combination of the main language title and address. You get this error when (multiple) matches already exist in the system.
+To ensure data integrity and avoid duplication within the system, each place must have a unique combination of the main language, title and address. You get this error when (multiple) matches already exist in the system.
 You can use the attached query to get existing place(s).
 Subsequently, appropriate actions, such as updates to an existing Place, can be done to maintain uniqueness and coherence in UDB.
 

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -3847,10 +3847,71 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "description": "Status conflict\n\nTo ensure data integrity and avoid duplication within the system, each place must have a unique combination of the main language title and address. You get this error when (multiple) matches already exist in the system.\nYou can use the attached query to get existing place(s).\nSubsequently, appropriate actions, such as updates to an existing Place, can be done to maintain uniqueness and coherence in UDB.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "x-examples": {
+                    "Example 1": {
+                      "query": "/place/581314d4-637e-407b-ba35-8b60847012d0",
+                      "type": "https://api.publiq.be/probs/url/status-conflict",
+                      "title": "Status conflict",
+                      "status": 409,
+                      "detail": "This place already exists. Use the attached query to get existing place(s) for the place you tried to create."
+                    }
+                  },
+                  "properties": {
+                    "query": {
+                      "type": "string",
+                      "description": "URI to existing places"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "https://api.publiq.be/probs/url/status-conflict"
+                    },
+                    "title": {
+                      "type": "string",
+                      "description": "Status conflict"
+                    },
+                    "status": {
+                      "type": "integer",
+                      "description": "409\n"
+                    },
+                    "detail": {
+                      "type": "string",
+                      "description": "Detailed description of the error"
+                    }
+                  }
+                },
+                "examples": {
+                  "Multi duplicated places found": {
+                    "value": {
+                      "query": "/place/581314d4-637e-407b-ba35-8b60847012d0",
+                      "type": "https://api.publiq.be/probs/url/status-conflict",
+                      "title": "Status conflict",
+                      "status": 409,
+                      "detail": "This place already exists. Use the attached query to get existing place(s) for the place you tried to create."
+                    }
+                  },
+                  "Single duplicated place found": {
+                    "value": {
+                      "query": "/place/581314d4-637e-407b-ba35-8b60847012d0",
+                      "type": "https://api.publiq.be/probs/url/status-conflict",
+                      "title": "Status conflict",
+                      "status": 409,
+                      "detail": "A place with this address / name combination already exists. Please use the existing place for your purposes."
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "place-post",
-        "description": "Creates a new place with the required properties and any additional optional properties.\n\nBy default, the new place will be editable and removable by the user or client that the access token used to perform this request belongs to. If you use a user access token, the user for which the token was obtained will see the new place in their dashboard in UiTdatabank and will be able to edit or remove it. If you use a client access token, only API requests with a token for the same client will be able to edit or remove it.",
+        "description": "Creates a new place with the required properties and any additional optional properties.\n\nBy default, the new place will be editable and removable by the user or client that the access token used to perform this request belongs to. If you use a user access token, the user for which the token was obtained will see the new place in their dashboard in UiTdatabank and will be able to edit or remove it. If you use a client access token, only API requests with a token for the same client will be able to edit or remove it.\n\nTo ensure data integrity and avoid duplication within the system, each place must have a unique combination of the main language title and address.",
         "security": [
           {
             "USER_ACCESS_TOKEN": []

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -3866,7 +3866,7 @@
                   "properties": {
                     "query": {
                       "type": "string",
-                      "description": "URI to existing places"
+                      "description": "When multiple duplicated places are round, this provides a URI to existing places"
                     },
                     "type": {
                       "type": "string",
@@ -3883,8 +3883,21 @@
                     "detail": {
                       "type": "string",
                       "description": "Detailed description of the error"
+                    },
+                    "duplicatePlaceUri": {
+                      "type": "string",
+                      "x-stoplight": {
+                        "id": "625qzdfcsviv2"
+                      },
+                      "description": "When a single duplicated place is found, this is the URI of the original place"
                     }
-                  }
+                  },
+                  "required": [
+                    "type",
+                    "title",
+                    "status",
+                    "detail"
+                  ]
                 },
                 "examples": {
                   "Multi duplicated places found": {
@@ -3898,7 +3911,7 @@
                   },
                   "Single duplicated place found": {
                     "value": {
-                      "query": "/place/581314d4-637e-407b-ba35-8b60847012d0",
+                      "duplicatePlaceUri": "/place/581314d4-637e-407b-ba35-8b60847012d0",
                       "type": "https://api.publiq.be/probs/url/status-conflict",
                       "title": "Status conflict",
                       "status": 409,


### PR DESCRIPTION
### Added
There is now a duplicate places check when creating a place.
This throws a 409 status code. 
This PR documents the new error.

Related to: https://github.com/cultuurnet/udb3-backend/pull/1600

---

Ticket: https://jira.uitdatabank.be/browse/III-4601
