### PR TITLE
III-6034 update info about availalbeTo for Camping Events

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/publish.md
+++ b/projects/uitdatabank/docs/entry-api/events/publish.md
@@ -60,7 +60,7 @@ Keep in mind that deleting an event is an irreversible action. If you deleted an
 
 > Note that you must not delete an event just because its end date has been reached. UiTinVlaanderen and other online calendars will automatically hide the event once its end date (`availableTo` property) has been reached.
 >
-> In the case of most events, this is the same as the end date of the event. Only in the case of events with the type *"lessenreeks"* is it the start date of the event, because you can usually no longer register to participate in such an event after it has started.
+> In the case of most events, this is the same as the end date of the event. Only in the case of events with the type *"lessenreeks"* or *"Kamp of vakantie"* is it the start date of the event, because you can usually no longer register to participate in such an event after it has started.
 
 ## Publishing an event as an API integrator
 

--- a/projects/uitdatabank/docs/search-api/advanced/advanced-queries.md
+++ b/projects/uitdatabank/docs/search-api/advanced/advanced-queries.md
@@ -190,7 +190,7 @@ Using the `availableRange` field, you can get all events and places that were av
 
 > By default, the search API will only return results that are currently available. In order to also retrieve results that are not available (yet), you'll need to disable the default filters for `availability`. You can reset this default as described in the [default filters guide](../filters/default-filters.md).
 
-Most events in UiTdatabank have a limited availability, from the time they are published (or their scheduled publication date has been reached) until the end date of the event. Specific types of events are only available until the start date of an event (e.g. a course series).
+Most events in UiTdatabank have a limited availability, from the time they are published (or their scheduled publication date has been reached) until the end date of the event. Specific types of events are only available until the start date of an event (e.g. a course series or Camping).
 
 Places are considered to be permanently available, starting when they are published (or, again, when their scheduled publication date has been reached). A small portion of the events is permanent as well, depending on their calendar information.
 


### PR DESCRIPTION
### Changed

- `uitdatabank/docs/entry-api/events/publish.md`: Update info about `Types` that are available till start(e.g., camping)
- `uitdatabank/docs/entry-api/events/publish.md`: Update info about `Camping` that is available till startDate.

---

Ticket: https://jira.publiq.be/browse/III-6034
