### PR TITLE
Add alert about label exception

### DIFF
--- a/projects/uitdatabank/docs/entry-api/shared/labels.md
+++ b/projects/uitdatabank/docs/entry-api/shared/labels.md
@@ -5,7 +5,7 @@ agenda. They can be public or private & visible or hidden.
 
 ## Scope
 
-Contributors can be added on:
+Labels can be added on:
 
 * ✅ [Events](../events/introduction.md)
 * ✅ [Places](../places/introduction.md)

--- a/projects/uitdatabank/docs/entry-api/shared/labels.md
+++ b/projects/uitdatabank/docs/entry-api/shared/labels.md
@@ -59,6 +59,10 @@ Alternatively, you can set a label using one of these endpoints:
 
 To remove a label **when updating an event/place/organizer in its entirety**, you can simply leave out the specific `label`.
 
+<!-- theme: danger -->
+>
+> Exception: some existing labels or hiddenLabels may be kept on the event even if they are not included in the update request. For example if they were added via the UiTdatabank UI, or if the client or user making the request does not have sufficient permission to remove some specific labels.
+
 Alternatively, you can delete a label using one of these endpoints:
 
 * For events: [`DELETE /events/{eventId}/labels/{labelName}`](/reference/entry.json/paths/~1events~1{eventId}~1labels~1{labelName}/delete)

--- a/projects/uitdatabank/docs/entry-api/shared/labels.md
+++ b/projects/uitdatabank/docs/entry-api/shared/labels.md
@@ -61,7 +61,7 @@ To remove a label **when updating an event/place/organizer in its entirety**, yo
 
 <!-- theme: danger -->
 >
-> Exception: some existing labels or hiddenLabels may be kept on the event even if they are not included in the update request. For example if they were added via the UiTdatabank UI, or if the client or user making the request does not have sufficient permission to remove some specific labels.
+> Exception: some existing labels or hiddenLabels may be kept on the event, even if they are not included in the update request. For example, if they were added via the UiTdatabank UI, or if the client or user making the request does not have sufficient permission to remove some specific labels.
 
 Alternatively, you can delete a label using one of these endpoints:
 


### PR DESCRIPTION
### Context
- In the current documentation page about labels it is not very clear if you can delete _all_ labels from an event or not.
- On other pages like https://docs.publiq.be/docs/uitdatabank/entry-api%2Freference%2Foperations%2Fupdate-a-event we already had an alert about labels being kept on the event after an update.

This PR adds this alert to the label documentation page

![Screenshot 2024-02-21 at 11 09 54](https://github.com/cultuurnet/apidocs/assets/29090370/4b4eae21-74c9-4e88-9bc5-d76b8e27d794)

### Added
- Add alert

### Fixed
- Typo

---

