### PR TITLE
Remove link to shared contributors page from side bar

### DIFF
--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -254,12 +254,6 @@
             },
             {
               "type": "item",
-              "title": "Contributors",
-              "uri": "/docs/entry-api/shared/contributors.md",
-              "slug": "entry-api/shared/contributors"
-            },
-            {
-              "type": "item",
               "title": "Description",
               "uri": "/docs/entry-api/shared/description.md",
               "slug": "entry-api/shared/description"


### PR DESCRIPTION
### Removed
- Link to contributors docs from side bar

Actual documentation page remains (for now) but with the changes from this PR you won't be able to navigate to the page using the sidebar 

---

Ticket: https://jira.uitdatabank.be/browse/III-6054
