### PR TITLE
III-6147 New internal endpoint - subscribe to newsletter

### DIFF
--- a/projects/uitdatabank/docs/errors.md
+++ b/projects/uitdatabank/docs/errors.md
@@ -125,3 +125,21 @@ Subsequently, appropriate actions, such as updates to an existing Place, can be 
   "duplicatePlaceUrl": "/place/581314d4-637e-407b-ba35-8b60847012d0"
 }
 ```
+
+## failed-subscription-to-newsletter
+
+* **Complete type:** `https://api.publiq.be/probs/uitdatabank/duplicate-place`
+* **Title**: `https://api.publiq.be/probs/uitdatabank/failed-subscription-to-newsletter`
+* **Status**: `400`
+
+When trying to subscribe to a newsletter, you might get this error when there are problems with the external e-mail service.
+The *detail* will contain the error message from the mail service.
+
+```json
+{
+  "type": "https://api.publiq.be/probs/uitdatabank/failed-subscription-to-newsletter",
+  "title": "Failed to subscribe to newsletter",
+  "status": 400,
+  "detail": "Details of the mailservice error",
+}
+```

--- a/projects/uitdatabank/docs/errors.md
+++ b/projects/uitdatabank/docs/errors.md
@@ -125,21 +125,3 @@ Subsequently, appropriate actions, such as updates to an existing Place, can be 
   "duplicatePlaceUrl": "/place/581314d4-637e-407b-ba35-8b60847012d0"
 }
 ```
-
-## failed-subscription-to-newsletter
-
-* **Complete type:** `https://api.publiq.be/probs/uitdatabank/duplicate-place`
-* **Title**: `https://api.publiq.be/probs/uitdatabank/failed-subscription-to-newsletter`
-* **Status**: `400`
-
-When trying to subscribe to a newsletter, you might get this error when there are problems with the external e-mail service.
-The *detail* will contain the error message from the mail service.
-
-```json
-{
-  "type": "https://api.publiq.be/probs/uitdatabank/failed-subscription-to-newsletter",
-  "title": "Failed to subscribe to newsletter",
-  "status": 400,
-  "detail": "Details of the mailservice error",
-}
-```

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -9049,7 +9049,7 @@
             "description": "No Content"
           },
           "400": {
-            "description": "Bad Request. Possible error types:\n\n* https://api.publiq.be/probs/body/missing\n* https://api.publiq.be/probs/body/invalid-syntax\n* https://api.publiq.be/probs/body/invalid-data",
+            "description": "Bad Request. Possible error types:\n\n* https://api.publiq.be/probs/body/missing\n* https://api.publiq.be/probs/body/invalid-syntax\n* https://api.publiq.be/probs/body/invalid-data\n* https://api.publiq.be/probs/uitdatabank/failed-subscription-to-newsletter",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -9025,6 +9025,119 @@
           }
         ]
       }
+    },
+    "/mailinglist/{mailinglistId}": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "integer"
+          },
+          "name": "mailinglistId",
+          "in": "path",
+          "required": true,
+          "description": "The mailinglist id"
+        }
+      ],
+      "put": {
+        "summary": "Subscribe to mailinglist",
+        "operationId": "put-mailinglist-mailinglistId",
+        "tags": [
+          "Mailing"
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request. Possible error types:\n\n* https://api.publiq.be/probs/body/missing\n* https://api.publiq.be/probs/body/invalid-syntax\n* https://api.publiq.be/probs/body/invalid-data",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "The given request body could not be parsed as json": {
+                    "value": {
+                      "type": "https://api.publiq.be/probs/body/invalid-syntax",
+                      "title": "Invalid body syntax",
+                      "status": 400,
+                      "detail": "The given request body could not be parsed as json."
+                    }
+                  },
+                  "The property email is required": {
+                    "value": {
+                      "type": "https://api.publiq.be/probs/body/invalid-data",
+                      "title": "Invalid body data",
+                      "status": 400,
+                      "schemaErrors": [
+                        {
+                          "jsonPointer": "/",
+                          "error": "The property 'email' is required."
+                        }
+                      ]
+                    }
+                  },
+                  "The given request body could not be parsed as json.": {
+                    "value": {
+                      "type": "https://api.publiq.be/probs/body/invalid-syntax",
+                      "title": "Invalid body syntax",
+                      "status": 400,
+                      "detail": "The given request body could not be parsed as json."
+                    }
+                  },
+                  "Failed to subscribe to newsletter": {
+                    "value": {
+                      "type": "https://api.publiq.be/probs/uitdatabank/failed-subscription-to-newsletter",
+                      "title": "Failed to subscribe to newsletter",
+                      "status": 400,
+                      "detail": "Details of the mailservice error"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "x-examples": {
+                  "Example 1": {
+                    "email": "koen@test.be"
+                  }
+                },
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "description": "Must be a valid e-mail address"
+                  }
+                }
+              },
+              "examples": {
+                "Example": {
+                  "value": {
+                    "email": "john.doe@publiq.be"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Send the email to subscribe."
+        },
+        "parameters": [],
+        "description": "This endpoint allows users to subscribe an email address to a specified mailing list.",
+        "x-internal": true,
+        "security": [
+          {
+            "USER_ACCESS_TOKEN": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -9250,6 +9363,9 @@
     },
     {
       "name": "Images"
+    },
+    {
+      "name": "Mailing"
     },
     {
       "name": "News articles"


### PR DESCRIPTION
### Added

- Added a new internal endpoint to subscribe to a newsletter
- Added a new error that can happen if newsletter subscription failed 

Read the docs: https://docs.publiq.be/docs/uitdatabank/branches/III-6147%2Fnew-mail-subscription-endpoint/entry-api/reference/operations/update-a-mailinglist

![Screenshot 2024-04-17 at 14 42 30](https://github.com/cultuurnet/apidocs/assets/13052911/93e7da48-8ef4-4196-a4a8-9d061231df44)

---

Ticket: https://jira.uitdatabank.be/browse/III-6147