### PR TITLE
III-6312 Allow encoded space

### DIFF
--- a/projects/uitdatabank/models/common-string-uri-image.json
+++ b/projects/uitdatabank/models/common-string-uri-image.json
@@ -1,8 +1,7 @@
 {
   "title": "uri",
   "type": "string",
-  "format": "uri",
-  "pattern": "^http(s?):([/|.|\\w|\\s|-])*\\.(?:jpeg|jpg|gif|png)$",
+  "pattern": "^http(s?):([/|.|\\w|%20|-])*\\.(?:jpeg|jpg|gif|png)$",
   "examples": [
     "https://www.example.com/sample.jpeg"
   ],


### PR DESCRIPTION
### Changed
- Allowed encoded space for the image URL of a news article. Only an encoded space is allowed to not interfere with the `Url` value object validation in `udb3-backed`

### Note
- Related pull request https://github.com/cultuurnet/udb3-backend/pull/1864

---

Ticket: https://jira.uitdatabank.be/browse/III-6312
