### PR TITLE
UPS-4849 use explicit model because new inline models mess up code ge…

### DIFF
--- a/projects/api-design-guidelines/docs/rest.md
+++ b/projects/api-design-guidelines/docs/rest.md
@@ -117,7 +117,7 @@ The `PATCH` method is used to do partial updates of existing resources on an API
 
 This contrasts with `PUT` which does updates using a complete representation of the resource, and must always be idempotent.
 
-The `PATCH` method should be avoided on APIs built by/for publiq, until we have agreed on a standardized approach like using [JSON PATCH](http://jsonpatch.com/) or [Merge PATCH](https://datatracker.ietf.org/doc/rfc7396/).
+The `PATCH` method should be avoided on APIs built by/for publiq, until we have agreed on a standardized approach like [Merge PATCH](https://datatracker.ietf.org/doc/rfc7396/).
 
 **DELETE**
 

--- a/projects/uitpas/reference/uitpas.json
+++ b/projects/uitpas/reference/uitpas.json
@@ -1602,19 +1602,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "downloadLink": {
-                      "type": "string",
-                      "x-stoplight": {
-                        "id": "g8c5z7be3lp76"
-                      },
-                      "description": "Download link for the QR checkin code"
-                    }
-                  },
-                  "required": [
-                    "downloadLink"
-                  ]
+                  "$ref": "#/components/schemas/DownloadLinkResponse"
                 },
                 "examples": {
                   "Example": {
@@ -9344,6 +9332,25 @@
         },
         "required": [
           "pictureUrl"
+        ]
+      },
+      "DownloadLinkResponse": {
+        "title": "DownloadLinkResponse",
+        "x-stoplight": {
+          "id": "a922luo99cksx"
+        },
+        "type": "object",
+        "properties": {
+          "downloadLink": {
+            "type": "string",
+            "x-stoplight": {
+              "id": "3opxrhpcw3s6u"
+            },
+            "description": "Download link for the requested file"
+          }
+        },
+        "required": [
+          "downloadLink"
         ]
       }
     },


### PR DESCRIPTION
### Fixed

- use explicit model because new inline models mess up code generation

---

Ticket: https://jira.uitdatabank.be/browse/UPS-4849
