### PR TITLE
III-6579 Endpoint municipalities and education levels

### DIFF
--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -9507,7 +9507,8 @@
             "headers": {
               "content-type": {
                 "schema": {
-                  "type": "string"
+                  "type": "string",
+                  "example": "application/json"
                 },
                 "description": "application/json"
               }
@@ -9529,6 +9530,7 @@
                       },
                       "children": {
                         "type": "array",
+                        "description": "Divisions of this region",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -9542,6 +9544,7 @@
                             },
                             "children": {
                               "type": "array",
+                              "description": "Divisions of this region",
                               "items": {
                                 "type": "object",
                                 "properties": {
@@ -9670,9 +9673,6 @@
         },
         "operationId": "get-regions",
         "x-internal": true,
-        "requestBody": {
-          "content": {}
-        },
         "parameters": [],
         "description": "Returns a hierarchical list of the regions in Flanders and Brussel. Each level includes a label, value with the NIS-code, and optional nested children, allowing integrators to display lists of all regions and municipalities."
       }
@@ -9687,7 +9687,8 @@
             "headers": {
               "content-type": {
                 "schema": {
-                  "type": "string"
+                  "type": "string",
+                  "example": "application/json"
                 },
                 "description": "application/json"
               }
@@ -9709,6 +9710,7 @@
                       },
                       "children": {
                         "type": "array",
+                        "description": "Divisions of this education level",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -9722,6 +9724,7 @@
                             },
                             "children": {
                               "type": "array",
+                              "description": "Divisions of this education level",
                               "items": {
                                 "type": "object",
                                 "properties": {
@@ -9804,9 +9807,6 @@
         },
         "operationId": "get-education-levels",
         "x-internal": true,
-        "requestBody": {
-          "content": {}
-        },
         "parameters": [],
         "description": "Returns a hierarchical list of education levels used on Cultuurkuur. Each level includes a label, value, and optional nested children, allowing integrators to display or process education structures ranging from early childhood to higher education."
       }
@@ -10066,10 +10066,10 @@
       "name": "Productions"
     },
     {
-      "name": "Users"
+      "name": "Taxonomy"
     },
     {
-      "name": "Taxonomy"
+      "name": "Users"
     }
   ]
 }

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -9497,10 +9497,10 @@
         ]
       }
     },
-    "/regions": {
+    "/cultuurkuur/regions": {
       "get": {
-        "summary": "/regions",
-        "tags": ["Taxonomy"],
+        "summary": "/cultuurkuur/regions",
+        "tags": ["Cultuurkuur"],
         "responses": {
           "200": {
             "description": "OK",
@@ -9677,10 +9677,10 @@
         "description": "Returns a hierarchical list of the regions in Flanders and Brussel. Each level includes a label, value with the NIS-code, and optional nested children, allowing integrators to display lists of all regions and municipalities."
       }
     },
-    "/education-levels": {
+    "/cultuurkuur/education-levels": {
       "get": {
-        "summary": "/education-levels",
-        "tags": ["Taxonomy"],
+        "summary": "/cultuurkuur/education-levels",
+        "tags": ["Cultuurkuur"],
         "responses": {
           "200": {
             "description": "OK",
@@ -10042,6 +10042,9 @@
   },
   "tags": [
     {
+      "name": "Cultuurkuur"
+    },
+    {
       "name": "Events"
     },
     {
@@ -10064,9 +10067,6 @@
     },
     {
       "name": "Productions"
-    },
-    {
-      "name": "Taxonomy"
     },
     {
       "name": "Users"

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -9500,7 +9500,7 @@
     "/regions": {
       "get": {
         "summary": "/regions",
-        "tags": [],
+        "tags": ["Taxonomy"],
         "responses": {
           "200": {
             "description": "OK",
@@ -9520,10 +9520,12 @@
                     "type": "object",
                     "properties": {
                       "label": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Name region"
                       },
                       "value": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "NIS code"
                       },
                       "children": {
                         "type": "array",
@@ -9531,10 +9533,12 @@
                           "type": "object",
                           "properties": {
                             "label": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Name region"
                             },
                             "value": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "NIS code"
                             },
                             "children": {
                               "type": "array",
@@ -9542,10 +9546,12 @@
                                 "type": "object",
                                 "properties": {
                                   "label": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "description": "Name region"
                                   },
                                   "value": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "description": "NIS code"
                                   }
                                 }
                               }
@@ -9674,7 +9680,7 @@
     "/education-levels": {
       "get": {
         "summary": "/education-levels",
-        "tags": [],
+        "tags": ["Taxonomy"],
         "responses": {
           "200": {
             "description": "OK",
@@ -9694,10 +9700,12 @@
                     "type": "object",
                     "properties": {
                       "label": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Educational level"
                       },
                       "value": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Slugified internal name"
                       },
                       "children": {
                         "type": "array",
@@ -9705,10 +9713,12 @@
                           "type": "object",
                           "properties": {
                             "label": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Educational level"
                             },
                             "value": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Slugified internal name"
                             },
                             "children": {
                               "type": "array",
@@ -9716,10 +9726,12 @@
                                 "type": "object",
                                 "properties": {
                                   "label": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "description": "Educational level"
                                   },
                                   "value": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "description": "Slugified internal name"
                                   }
                                 }
                               }
@@ -10055,6 +10067,9 @@
     },
     {
       "name": "Users"
+    },
+    {
+      "name": "Taxonomy"
     }
   ]
 }

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -9499,8 +9499,10 @@
     },
     "/cultuurkuur/regions": {
       "get": {
-        "summary": "/cultuurkuur/regions",
-        "tags": ["Cultuurkuur"],
+        "summary": "regions - GET",
+        "tags": [
+          "Taxonomy"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -9520,41 +9522,59 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "name": {
+                        "description": "Name region in various languages",
+                        "type": "object",
+                        "properties": {
+                          "nl": {
+                            "description": "Name region in NL",
+                            "type": "string"
+                          }
+                        }
+                      },
                       "label": {
                         "type": "string",
-                        "description": "Name region"
-                      },
-                      "value": {
-                        "type": "string",
-                        "description": "NIS code"
+                        "description": "Label region"
                       },
                       "children": {
-                        "type": "array",
                         "description": "Divisions of this region",
+                        "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "label": {
-                              "type": "string",
-                              "description": "Name region"
+                            "name": {
+                              "description": "Name region in various languages",
+                              "type": "object",
+                              "properties": {
+                                "nl": {
+                                  "description": "Name region in NL",
+                                  "type": "string"
+                                }
+                              }
                             },
-                            "value": {
-                              "type": "string",
-                              "description": "NIS code"
+                            "label": {
+                              "description": "Label region",
+                              "type": "string"
                             },
                             "children": {
-                              "type": "array",
                               "description": "Divisions of this region",
+                              "type": "array",
                               "items": {
                                 "type": "object",
                                 "properties": {
-                                  "label": {
-                                    "type": "string",
-                                    "description": "Name region"
+                                  "name": {
+                                    "description": "Name region in various languages",
+                                    "type": "object",
+                                    "properties": {
+                                      "nl": {
+                                        "description": "Name region in NL",
+                                        "type": "string"
+                                      }
+                                    }
                                   },
-                                  "value": {
-                                    "type": "string",
-                                    "description": "NIS code"
+                                  "label": {
+                                    "description": "Label region",
+                                    "type": "string"
                                   }
                                 }
                               }
@@ -9567,24 +9587,8088 @@
                   "x-examples": {
                     "Example 1": [
                       {
-                        "label": "Brussels Hoofdstedelijk Gewest",
-                        "value": "nis-01000",
+                        "name": {
+                          "nl": "Brussels Hoofdstedelijk Gewest"
+                        },
+                        "label": "cultuurkuur_werkingsregio_provincie_nis-01000",
                         "children": [
                           {
-                            "label": "Regio Brussel",
-                            "value": "reg-brussel",
+                            "name": {
+                              "nl": "Regio Brussel"
+                            },
+                            "label": "reg-brussel",
                             "children": [
                               {
-                                "label": "Anderlecht + deelgemeenten",
-                                "value": "nis-21001"
+                                "name": {
+                                  "nl": "Anderlecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21001"
                               },
                               {
-                                "label": "Brussel + deelgemeenten",
-                                "value": "nis-21004"
+                                "name": {
+                                  "nl": "Brussel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21004"
                               },
                               {
-                                "label": "Elsene + deelgemeenten",
-                                "value": "nis-21009"
+                                "name": {
+                                  "nl": "Elsene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Etterbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Evere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ganshoren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Jette + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koekelberg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schaarbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21015"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Agatha-Berchem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Gillis + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Jans-Molenbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Joost-ten-Node + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Lambrechts-Woluwe + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Pieters-Woluwe + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ukkel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vorst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Watermaal-Bosvoorde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21017"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Provincie Antwerpen"
+                        },
+                        "label": "cultuurkuur_werkingsregio_provincie_nis-10000",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Regio Antwerpen"
+                            },
+                            "label": "reg-antwerpen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Antwerpen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wommelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boechout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lint + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kontich + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aartselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mortsel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Edegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hemiksem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rumst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Niel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Willebroek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bornem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Puurs-Sint-Amands + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wijnegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11050"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zandhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11054"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Malle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11057"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ranst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schoten + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Essen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kalmthout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brasschaat + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stabroek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kapellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schilde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zoersel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11055"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wuustwezel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Duffel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bonheiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Katelijne-Waver + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herentals + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hulshout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Olen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Westerlo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13049"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herenthout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lille + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Grobbendonk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vorselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Turnhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rijkevorsel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoogstraten + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merksplas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beerse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vosselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13046"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oud-Turnhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13031"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Arendonk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ravels + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Baarle-Hertog + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mol + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laakdal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Meerhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kasterlee + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Retie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13036"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dessel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Balen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heist-op-den-Berg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lier + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nijlen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Putte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12002"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Mechelen"
+                            },
+                            "label": "reg-mechelen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Antwerpen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wommelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boechout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lint + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kontich + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aartselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mortsel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Edegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hemiksem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rumst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Niel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Willebroek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bornem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Puurs-Sint-Amands + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wijnegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11050"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zandhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11054"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Malle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11057"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ranst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schoten + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Essen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kalmthout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brasschaat + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stabroek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kapellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schilde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zoersel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11055"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wuustwezel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Duffel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bonheiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Katelijne-Waver + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herentals + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hulshout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Olen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Westerlo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13049"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herenthout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lille + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Grobbendonk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vorselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Turnhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rijkevorsel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoogstraten + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merksplas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beerse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vosselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13046"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oud-Turnhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13031"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Arendonk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ravels + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Baarle-Hertog + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mol + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laakdal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Meerhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kasterlee + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Retie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13036"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dessel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Balen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heist-op-den-Berg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lier + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nijlen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Putte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12002"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Scheldeland Antwerpen"
+                            },
+                            "label": "reg-scheldeland-antwerpen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Antwerpen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wommelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boechout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lint + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kontich + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aartselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mortsel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Edegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hemiksem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rumst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Niel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Willebroek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bornem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Puurs-Sint-Amands + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wijnegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11050"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zandhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11054"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Malle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11057"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ranst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schoten + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Essen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kalmthout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brasschaat + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stabroek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kapellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schilde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zoersel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11055"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wuustwezel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Duffel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bonheiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Katelijne-Waver + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herentals + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hulshout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Olen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Westerlo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13049"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herenthout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lille + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Grobbendonk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vorselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Turnhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rijkevorsel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoogstraten + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merksplas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beerse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vosselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13046"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oud-Turnhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13031"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Arendonk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ravels + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Baarle-Hertog + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mol + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laakdal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Meerhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kasterlee + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Retie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13036"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dessel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Balen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heist-op-den-Berg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lier + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nijlen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Putte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12002"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Kempen"
+                            },
+                            "label": "reg-kempen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Antwerpen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wommelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boechout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lint + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kontich + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aartselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mortsel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Edegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hemiksem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rumst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Niel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Willebroek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bornem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Puurs-Sint-Amands + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wijnegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11050"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zandhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11054"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Malle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11057"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ranst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schoten + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Essen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kalmthout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brasschaat + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stabroek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kapellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Schilde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zoersel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11055"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wuustwezel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-11053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Duffel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bonheiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Katelijne-Waver + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herentals + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hulshout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Olen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Westerlo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13049"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herenthout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lille + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Grobbendonk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vorselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Turnhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rijkevorsel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoogstraten + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merksplas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beerse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vosselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13046"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oud-Turnhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13031"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Arendonk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ravels + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Baarle-Hertog + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mol + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laakdal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Meerhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kasterlee + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Retie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13036"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dessel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Balen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-13003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heist-op-den-Berg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lier + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nijlen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Putte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-12002"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Provincie Vlaams-Brabant"
+                        },
+                        "label": "cultuurkuur_werkingsregio_provincie_nis-20001",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Regio Groene Gordel"
+                            },
+                            "label": "reg-groene-gordel",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Vilvoorde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23088"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Steenokkerzeel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Machelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23047"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Grimbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Meise + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23050"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kapelle-op-den-Bos + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kampenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zaventem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23094"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kraainem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23099"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wezembeek-Oppem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23103"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zemst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23096"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Halle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pajottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bever + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoeilaart + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Pieters-Leeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23077"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Drogenbos + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23098"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Linkebeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23100"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Genesius-Rode + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23101"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beersel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pepingen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dilbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Asse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ternat + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23086"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Opwijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lennik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23104"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Roosdaal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23097"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Liedekerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wemmel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23102"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merchtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Affligem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23105"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Londerzeel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Huldenberg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oud-Heverlee + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24086"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bertem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortenberg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24055"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tervuren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24104"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Overijse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Keerbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haacht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boortmeerbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aarschot + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Scherpenheuvel-Zichem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24134"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diest + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tienen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24107"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoegaarden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Linter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24133"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Glabbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24137"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tielt-Winge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24135"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zoutleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24130"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geetbets + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bekkevoort + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortenaken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24054"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rotselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24094"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tremelo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24109"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Begijnendijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lubbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Holsbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bierbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boutersem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Leuven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24062"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Hageland"
+                            },
+                            "label": "reg-hageland",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Vilvoorde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23088"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Steenokkerzeel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Machelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23047"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Grimbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Meise + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23050"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kapelle-op-den-Bos + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kampenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zaventem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23094"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kraainem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23099"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wezembeek-Oppem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23103"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zemst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23096"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Halle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pajottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bever + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoeilaart + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Pieters-Leeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23077"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Drogenbos + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23098"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Linkebeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23100"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Genesius-Rode + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23101"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beersel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pepingen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dilbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Asse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ternat + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23086"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Opwijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lennik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23104"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Roosdaal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23097"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Liedekerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wemmel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23102"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merchtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Affligem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23105"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Londerzeel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Huldenberg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oud-Heverlee + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24086"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bertem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortenberg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24055"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tervuren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24104"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Overijse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Keerbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haacht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boortmeerbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aarschot + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Scherpenheuvel-Zichem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24134"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diest + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tienen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24107"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoegaarden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Linter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24133"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Glabbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24137"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tielt-Winge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24135"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zoutleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24130"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geetbets + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bekkevoort + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortenaken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24054"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rotselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24094"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tremelo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24109"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Begijnendijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lubbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Holsbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bierbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boutersem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Leuven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24062"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Leuven"
+                            },
+                            "label": "reg-leuven",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Vilvoorde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23088"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Steenokkerzeel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Machelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23047"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Grimbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Meise + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23050"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kapelle-op-den-Bos + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kampenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zaventem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23094"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kraainem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23099"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wezembeek-Oppem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23103"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zemst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23096"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Halle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pajottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bever + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoeilaart + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Pieters-Leeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23077"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Drogenbos + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23098"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Linkebeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23100"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Genesius-Rode + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23101"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beersel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pepingen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dilbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Asse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ternat + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23086"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Opwijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lennik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23104"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Roosdaal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23097"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Liedekerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23044"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wemmel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23102"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merchtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Affligem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23105"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Londerzeel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Huldenberg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oud-Heverlee + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24086"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bertem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortenberg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24055"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tervuren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24104"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Overijse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-23062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Keerbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haacht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boortmeerbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aarschot + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Scherpenheuvel-Zichem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24134"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diest + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tienen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24107"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hoegaarden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Linter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24133"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Glabbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24137"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tielt-Winge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24135"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zoutleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24130"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geetbets + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bekkevoort + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortenaken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24054"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Rotselaar + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24094"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tremelo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24109"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Begijnendijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lubbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Holsbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bierbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Boutersem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Leuven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24062"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Provincie West-Vlaanderen"
+                        },
+                        "label": "cultuurkuur_werkingsregio_provincie_nis-30000",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Regio Brugge"
+                            },
+                            "label": "reg-brugge",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Brugge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostkamp + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zedelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Damme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zuienkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ichtegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Jabbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beernem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Torhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gistel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lichtervelde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tielt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pittem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wingene +deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ardooie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ingelmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Roeselare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36015"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Izegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ledegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Moorslede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wielsbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dentergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostrozebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortrijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kuurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Harelbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deerlijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwevegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wevelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Anzegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Avelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Spiere-Helkijn + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waregem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lendelede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Menen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Knokke-Heist + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Blankenberge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Haan + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bredene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Panne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostende + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Middelkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwpoort + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koksijde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hooglede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Staden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Veurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Alveringem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diksmuide + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortemark + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lo-Reninge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthulst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koekelare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vleteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ieper + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Langemark-Poelkapelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heuvelland + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mesen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Poperinge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonnebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wervik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33029"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Brugse Ommeland"
+                            },
+                            "label": "reg-brugse-ommeland",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Brugge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostkamp + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zedelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Damme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zuienkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ichtegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Jabbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beernem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Torhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gistel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lichtervelde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tielt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pittem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wingene +deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ardooie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ingelmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Roeselare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36015"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Izegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ledegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Moorslede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wielsbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dentergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostrozebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortrijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kuurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Harelbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deerlijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwevegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wevelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Anzegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Avelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Spiere-Helkijn + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waregem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lendelede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Menen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Knokke-Heist + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Blankenberge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Haan + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bredene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Panne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostende + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Middelkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwpoort + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koksijde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hooglede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Staden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Veurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Alveringem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diksmuide + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortemark + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lo-Reninge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthulst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koekelare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vleteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ieper + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Langemark-Poelkapelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heuvelland + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mesen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Poperinge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonnebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wervik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33029"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Leiestreek West-Vlaanderen"
+                            },
+                            "label": "reg-leiestreek-west-vlaanderen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Brugge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostkamp + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zedelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Damme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zuienkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ichtegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Jabbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beernem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Torhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gistel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lichtervelde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tielt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pittem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wingene +deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ardooie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ingelmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Roeselare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36015"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Izegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ledegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Moorslede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wielsbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dentergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostrozebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortrijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kuurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Harelbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deerlijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwevegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wevelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Anzegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Avelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Spiere-Helkijn + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waregem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lendelede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Menen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Knokke-Heist + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Blankenberge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Haan + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bredene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Panne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostende + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Middelkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwpoort + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koksijde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hooglede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Staden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Veurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Alveringem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diksmuide + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortemark + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lo-Reninge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthulst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koekelare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vleteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ieper + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Langemark-Poelkapelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heuvelland + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mesen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Poperinge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonnebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wervik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33029"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Vlaamse Kust"
+                            },
+                            "label": "reg-vlaamse-kust",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Brugge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostkamp + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zedelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Damme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zuienkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ichtegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Jabbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beernem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Torhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gistel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lichtervelde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tielt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pittem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wingene +deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ardooie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ingelmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Roeselare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36015"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Izegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ledegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Moorslede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wielsbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dentergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostrozebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortrijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kuurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Harelbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deerlijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwevegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wevelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Anzegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Avelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Spiere-Helkijn + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waregem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lendelede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Menen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Knokke-Heist + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Blankenberge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Haan + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bredene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Panne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostende + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Middelkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwpoort + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koksijde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hooglede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Staden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Veurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Alveringem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diksmuide + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortemark + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lo-Reninge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthulst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koekelare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vleteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ieper + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Langemark-Poelkapelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heuvelland + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mesen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Poperinge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonnebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wervik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33029"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Westhoek"
+                            },
+                            "label": "reg-westhoek",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Brugge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostkamp + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zedelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Damme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zuienkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ichtegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Jabbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beernem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Torhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31033"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gistel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lichtervelde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tielt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pittem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wingene +deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ardooie + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ingelmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Roeselare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36015"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Izegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ledegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Moorslede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wielsbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dentergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostrozebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-37010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortrijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kuurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Harelbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deerlijk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwevegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wevelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Anzegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Avelgem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Spiere-Helkijn + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waregem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lendelede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Menen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-34027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Knokke-Heist + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Blankenberge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-31004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Haan + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35029"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bredene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "De Panne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oostende + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Middelkerke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-35011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwpoort + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koksijde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hooglede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Staden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-36019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Veurne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Alveringem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-38002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diksmuide + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kortemark + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lo-Reninge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthulst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Koekelare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-32010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Vleteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ieper + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Langemark-Poelkapelle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33040"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heuvelland + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Mesen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Poperinge + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonnebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wervik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-33029"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Provincie Oost-Vlaanderen"
+                        },
+                        "label": "cultuurkuur_werkingsregio_provincie_nis-40000",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Regio Gent"
+                            },
+                            "label": "reg-gent",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Gent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nazareth-De Pinte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Martens-Latem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zulte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deinze + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44083"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zelzate + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Eeklo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Assenede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kaprijke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Laureins + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maldegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lochristi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Evergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44084"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lievegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44085"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geraardsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Lievens-Houtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lierde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ronse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwalm + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45065"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brakel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Horebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maarkedal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kluisbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenaarde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wortegem-Petegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45061"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oosterzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gavere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kruisem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45068"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Niklaas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Temse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lokeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Gillis-Waas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stekene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waasmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ninove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Erpe-Mere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41082"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haaltert + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Denderleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dendermonde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wetteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Buggenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wichelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laarne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lebbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Destelbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merelbeke-Melle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21008"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Leiestreek Oost-Vlaanderen"
+                            },
+                            "label": "reg-leiestreek-oost-vlaanderen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Gent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nazareth-De Pinte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Martens-Latem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zulte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deinze + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44083"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zelzate + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Eeklo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Assenede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kaprijke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Laureins + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maldegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lochristi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Evergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44084"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lievegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44085"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geraardsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Lievens-Houtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lierde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ronse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwalm + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45065"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brakel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Horebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maarkedal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kluisbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenaarde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wortegem-Petegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45061"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oosterzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gavere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kruisem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45068"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Niklaas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Temse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lokeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Gillis-Waas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stekene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waasmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ninove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Erpe-Mere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41082"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haaltert + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Denderleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dendermonde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wetteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Buggenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wichelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laarne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lebbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Destelbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merelbeke-Melle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21008"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Meetjesland"
+                            },
+                            "label": "reg-meetjesland",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Gent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nazareth-De Pinte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Martens-Latem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zulte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deinze + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44083"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zelzate + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Eeklo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Assenede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kaprijke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Laureins + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maldegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lochristi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Evergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44084"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lievegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44085"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geraardsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Lievens-Houtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lierde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ronse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwalm + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45065"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brakel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Horebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maarkedal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kluisbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenaarde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wortegem-Petegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45061"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oosterzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gavere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kruisem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45068"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Niklaas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Temse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lokeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Gillis-Waas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stekene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waasmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ninove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Erpe-Mere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41082"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haaltert + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Denderleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dendermonde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wetteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Buggenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wichelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laarne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lebbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Destelbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merelbeke-Melle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21008"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Vlaamse Ardennen"
+                            },
+                            "label": "reg-vlaamse-ardennen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Gent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nazareth-De Pinte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Martens-Latem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zulte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deinze + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44083"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zelzate + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Eeklo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Assenede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kaprijke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Laureins + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maldegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lochristi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Evergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44084"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lievegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44085"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geraardsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Lievens-Houtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lierde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ronse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwalm + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45065"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brakel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Horebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maarkedal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kluisbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenaarde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wortegem-Petegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45061"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oosterzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gavere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kruisem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45068"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Niklaas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Temse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lokeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Gillis-Waas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stekene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waasmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ninove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Erpe-Mere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41082"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haaltert + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Denderleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dendermonde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wetteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Buggenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wichelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laarne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lebbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Destelbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merelbeke-Melle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21008"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Waasland"
+                            },
+                            "label": "reg-waasland",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Gent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nazareth-De Pinte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Martens-Latem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zulte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deinze + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44083"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zelzate + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Eeklo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Assenede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kaprijke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Laureins + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maldegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lochristi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Evergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44084"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lievegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44085"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geraardsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Lievens-Houtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lierde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ronse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwalm + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45065"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brakel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Horebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maarkedal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kluisbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenaarde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wortegem-Petegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45061"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oosterzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gavere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kruisem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45068"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Niklaas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Temse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lokeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Gillis-Waas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stekene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waasmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ninove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Erpe-Mere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41082"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haaltert + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Denderleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dendermonde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wetteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Buggenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wichelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laarne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lebbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Destelbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merelbeke-Melle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21008"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Scheldeland Oost-Vlaanderen"
+                            },
+                            "label": "reg-scheldeland-oost-vlaanderen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Gent + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nazareth-De Pinte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Martens-Latem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zulte + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Deinze + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44083"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zelzate + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Eeklo + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Assenede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kaprijke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Laureins + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43014"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maldegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-43010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lochristi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21005"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Evergem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44019"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalter + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44084"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lievegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44085"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Geraardsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Lievens-Houtem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41027"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zottegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41081"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lierde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45063"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ronse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zwalm + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45065"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Brakel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Horebeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45062"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maarkedal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45064"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kluisbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45060"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudenaarde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45035"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wortegem-Petegem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45061"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oosterzele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44052"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gavere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kruisem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-45068"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Niklaas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beveren-Kruibeke-Zwijndrecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Temse + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lokeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21007"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Gillis-Waas + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Stekene + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-46024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Waasmunster + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42023"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Aalst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lede + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Ninove + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41048"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Erpe-Mere + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41082"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Haaltert + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Denderleeuw + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-41011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dendermonde + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42006"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamme + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42008"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wetteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42025"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zele + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Buggenhout + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wichelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42026"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Laarne + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lebbeke + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Berlare + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-42003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Destelbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-44013"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Merelbeke-Melle + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21008"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Provincie Limburg"
+                        },
+                        "label": "cultuurkuur_werkingsregio_provincie_nis-70000",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Regio Haspengouw"
+                            },
+                            "label": "reg-haspengouw",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Alken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tongeren-Borgloon + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herstappe + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bilzen-Hoeselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Riemst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Truiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73098"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heers + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gingelom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herk-de-Stad + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Halen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwerkerken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Landen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hasselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthalen-Helchteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lommel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamont-Achel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hechtel-Eksel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bocholt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bree + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Peer + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heusden-Zolder + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71070"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lummen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beringen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diepenbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Genk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "As + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zutendaal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71067"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tessenderlo-Ham + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Leopoldsburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pelt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kinrooi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dilsen-Stokkem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maaseik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lanaken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maasmechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73107"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Voeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73109"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Hasselt"
+                            },
+                            "label": "reg-hasselt",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Alken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tongeren-Borgloon + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herstappe + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bilzen-Hoeselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Riemst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Truiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73098"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heers + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gingelom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herk-de-Stad + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Halen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwerkerken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Landen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hasselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthalen-Helchteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lommel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamont-Achel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hechtel-Eksel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bocholt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bree + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Peer + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heusden-Zolder + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71070"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lummen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beringen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diepenbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Genk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "As + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zutendaal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71067"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tessenderlo-Ham + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Leopoldsburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pelt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kinrooi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dilsen-Stokkem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maaseik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lanaken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maasmechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73107"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Voeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73109"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Limburgse Kempen"
+                            },
+                            "label": "reg-limburgse-kempen",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Alken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tongeren-Borgloon + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herstappe + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bilzen-Hoeselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Riemst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Truiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73098"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heers + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gingelom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herk-de-Stad + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Halen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwerkerken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Landen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hasselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthalen-Helchteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lommel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamont-Achel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hechtel-Eksel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bocholt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bree + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Peer + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heusden-Zolder + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71070"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lummen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beringen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diepenbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Genk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "As + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zutendaal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71067"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tessenderlo-Ham + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Leopoldsburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pelt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kinrooi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dilsen-Stokkem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maaseik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lanaken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maasmechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73107"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Voeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73109"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Maasland"
+                            },
+                            "label": "reg-maasland",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Alken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tongeren-Borgloon + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herstappe + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bilzen-Hoeselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Riemst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Truiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73098"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heers + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gingelom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herk-de-Stad + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Halen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwerkerken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Landen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hasselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthalen-Helchteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lommel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamont-Achel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hechtel-Eksel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bocholt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bree + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Peer + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heusden-Zolder + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71070"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lummen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beringen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diepenbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Genk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "As + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zutendaal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71067"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tessenderlo-Ham + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Leopoldsburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pelt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kinrooi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dilsen-Stokkem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maaseik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lanaken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maasmechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73107"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Voeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73109"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Regio Voerstreek"
+                            },
+                            "label": "reg-voerstreek",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Alken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73001"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tongeren-Borgloon + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21009"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herstappe + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73028"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bilzen-Hoeselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21010"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Riemst + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Sint-Truiden + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71053"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Wellen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73098"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heers + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73022"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gingelom + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71017"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Herk-de-Stad + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71024"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Halen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Nieuwerkerken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71045"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Landen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-24059"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hasselt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Houthalen-Helchteren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72039"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lommel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72020"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hamont-Achel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Hechtel-Eksel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72038"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bocholt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72003"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Bree + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Peer + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72030"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zonhoven + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71066"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Heusden-Zolder + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71070"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lummen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71037"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Beringen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71004"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Diepenbeek + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71011"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Genk + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71016"
+                              },
+                              {
+                                "name": {
+                                  "nl": "As + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71002"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Zutendaal + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71067"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tessenderlo-Ham + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21012"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Leopoldsburg + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-71034"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Pelt + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72043"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Oudsbergen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Kinrooi + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72018"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Dilsen-Stokkem + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72041"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maaseik + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-72021"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Lanaken + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73042"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Maasmechelen + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73107"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Voeren + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-73109"
                               }
                             ]
                           }
@@ -9597,68 +17681,28 @@
                   "Example 1": {
                     "value": [
                       {
-                        "label": "Brussels Hoofdstedelijk Gewest",
-                        "value": "nis-01000",
+                        "name": {
+                          "nl": "Brussels Hoofdstedelijk Gewest"
+                        },
+                        "label": "cultuurkuur_werkingsregio_provincie_nis-01000",
                         "children": [
                           {
-                            "label": "Regio Brussel",
-                            "value": "reg-brussel",
+                            "name": {
+                              "nl": "Regio Brussel"
+                            },
+                            "label": "reg-brussel",
                             "children": [
                               {
-                                "label": "Anderlecht + deelgemeenten",
-                                "value": "nis-21001"
+                                "name": {
+                                  "nl": "Anderlecht + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21001"
                               },
                               {
-                                "label": "Brussel + deelgemeenten",
-                                "value": "nis-21004"
-                              },
-                              {
-                                "label": "Elsene + deelgemeenten",
-                                "value": "nis-21009"
-                              },
-                              {
-                                "label": "Etterbeek + deelgemeenten",
-                                "value": "nis-21005"
-                              },
-                              {
-                                "label": "Evere + deelgemeenten",
-                                "value": "nis-21006"
-                              },
-                              {
-                                "label": "Ganshoren + deelgemeenten",
-                                "value": "nis-21008"
-                              },
-                              {
-                                "label": "Jette + deelgemeenten",
-                                "value": "nis-21010"
-                              },
-                              {
-                                "label": "Koekelberg + deelgemeenten",
-                                "value": "nis-21011"
-                              },
-                              {
-                                "label": "Oudergem + deelgemeenten",
-                                "value": "nis-21002"
-                              },
-                              {
-                                "label": "Schaarbeek + deelgemeenten",
-                                "value": "nis-21015"
-                              },
-                              {
-                                "label": "Sint-Agatha-Berchem + deelgemeenten",
-                                "value": "nis-21003"
-                              },
-                              {
-                                "label": "Sint-Gillis + deelgemeenten",
-                                "value": "nis-21013"
-                              },
-                              {
-                                "label": "Sint-Jans-Molenbeek + deelgemeenten",
-                                "value": "nis-21012"
-                              },
-                              {
-                                "label": "Sint-Joost-ten-Node + deelgemeenten",
-                                "value": "nis-21014"
+                                "name": {
+                                  "nl": "Brussel + deelgemeenten"
+                                },
+                                "label": "cultuurkuur_werkingsregio_nis-21004"
                               }
                             ]
                           }
@@ -9679,8 +17723,10 @@
     },
     "/cultuurkuur/education-levels": {
       "get": {
-        "summary": "/cultuurkuur/education-levels",
-        "tags": ["Cultuurkuur"],
+        "summary": "educationLevels - GET",
+        "tags": [
+          "Taxonomy"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -9700,41 +17746,82 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "label": {
-                        "type": "string",
-                        "description": "Educational level"
+                      "name": {
+                        "description": "Educational level in various languages",
+                        "type": "object",
+                        "properties": {
+                          "nl": {
+                            "description": "Educational level in NL",
+                            "type": "string"
+                          }
+                        }
                       },
-                      "value": {
+                      "label": {
                         "type": "string",
                         "description": "Slugified internal name"
                       },
                       "children": {
-                        "type": "array",
                         "description": "Divisions of this education level",
+                        "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "label": {
-                              "type": "string",
-                              "description": "Educational level"
+                            "name": {
+                              "description": "Educational level in various languages",
+                              "type": "object",
+                              "properties": {
+                                "nl": {
+                                  "type": "string",
+                                  "description": "Educational level in NL"
+                                }
+                              }
                             },
-                            "value": {
+                            "label": {
                               "type": "string",
                               "description": "Slugified internal name"
                             },
                             "children": {
-                              "type": "array",
                               "description": "Divisions of this education level",
+                              "type": "array",
                               "items": {
                                 "type": "object",
                                 "properties": {
+                                  "name": {
+                                    "description": "Educational level in various languages",
+                                    "type": "object",
+                                    "properties": {
+                                      "nl": {
+                                        "type": "string",
+                                        "description": "Educational level in NL"
+                                      }
+                                    }
+                                  },
                                   "label": {
                                     "type": "string",
-                                    "description": "Educational level"
-                                  },
-                                  "value": {
-                                    "type": "string",
                                     "description": "Slugified internal name"
+                                  },
+                                  "children": {
+                                    "type": "array",
+                                    "description": "Divisions of this education level",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "object",
+                                          "description": "Educational level in various languages",
+                                          "properties": {
+                                            "nl": {
+                                              "type": "string",
+                                              "description": "Educational level in NL"
+                                            }
+                                          }
+                                        },
+                                        "label": {
+                                          "type": "string",
+                                          "description": "Slugified internal name"
+                                        }
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -9747,26 +17834,252 @@
                   "x-examples": {
                     "Example 1": [
                       {
-                        "label": "Brussels Hoofdstedelijk Gewest",
-                        "value": "nis-01000",
+                        "name": {
+                          "nl": "Basisonderwijs"
+                        },
+                        "label": "cultuurkuur_basisonderwijs",
                         "children": [
                           {
-                            "label": "Regio Brussel",
-                            "value": "reg-brussel",
+                            "name": {
+                              "nl": "Gewoon basisonderwijs"
+                            },
+                            "label": "cultuurkuur_Gewoon-basisonderwijs",
                             "children": [
                               {
-                                "label": "Anderlecht + deelgemeenten",
-                                "value": "nis-21001"
+                                "name": {
+                                  "nl": "Gewoon kleuteronderwijs"
+                                },
+                                "label": "cultuurkuur_Gewoon-kleuteronderwijs",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "Kleuter (2-3 jaar)"
+                                    },
+                                    "label": "cultuurkuur_Kleuter-2-3-jaar"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Kleuter (3-4 jaar)"
+                                    },
+                                    "label": "cultuurkuur_Kleuter-3-4-jaar"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Kleuter (4-5 jaar)"
+                                    },
+                                    "label": "cultuurkuur_Kleuter-4-5-jaar"
+                                  }
+                                ]
                               },
                               {
-                                "label": "Brussel + deelgemeenten",
-                                "value": "nis-21004"
+                                "name": {
+                                  "nl": "Gewoon lager onderwijs"
+                                },
+                                "label": "cultuurkuur_Gewoon-lager-onderwijs",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "Eerste graad"
+                                    },
+                                    "label": "cultuurkuur_1ste-graad"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Tweede graad"
+                                    },
+                                    "label": "cultuurkuur_2de-graad"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Derde graad"
+                                    },
+                                    "label": "cultuurkuur_3de-graad"
+                                  }
+                                ]
                               },
                               {
-                                "label": "Elsene + deelgemeenten",
-                                "value": "nis-21009"
+                                "name": {
+                                  "nl": "Onthaalonderwijs voor anderstalige nieuwkomers (OKAN)"
+                                },
+                                "label": "cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers (OKAN)"
                               }
                             ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Buitengewoon basisonderwijs"
+                            },
+                            "label": "cultuurkuur_Buitengewoon-basisonderwijs",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Buitengewoon kleuteronderwijs"
+                                },
+                                "label": "cultuurkuur_Buitengewoon-kleuteronderwijs"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Buitengewoon lager onderwijs"
+                                },
+                                "label": "cultuurkuur_Buitengewoon-lager-onderwijs"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Secundair onderwijs"
+                        },
+                        "label": "cultuurkuur_Secundair-onderwijs",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Voltijds gewoon secundair onderwijs"
+                            },
+                            "label": "cultuurkuur_Voltijds-gewoon-secundair-onderwijs",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Eerste graad"
+                                },
+                                "label": "cultuurkuur_eerste-graad",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "A-stroom"
+                                    },
+                                    "label": "cultuurkuur_A-stroom"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "B-stroom"
+                                    },
+                                    "label": "cultuurkuur_B-stroom"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tweede graad"
+                                },
+                                "label": "cultuurkuur_tweede-graad",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "Finaliteit doorstroom"
+                                    },
+                                    "label": "cultuurkuur_finaliteit-tweede-doorstroom"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Finaliteit arbeidsmarkt"
+                                    },
+                                    "label": "cultuurkuur_finaliteit-tweede-arbeidsmarkt"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Dubbele finaliteit"
+                                    },
+                                    "label": "cultuurkuur_dubbele-tweede-finaliteit"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": {
+                                  "nl": "Derde graad"
+                                },
+                                "label": "cultuurkuur_derde-graad",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "Finaliteit doorstroom"
+                                    },
+                                    "label": "cultuurkuur_finaliteit-derdre-doorstroom"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Finaliteit arbeidsmarkt"
+                                    },
+                                    "label": "cultuurkuur_finaliteit-derdre-arbeidsmarkt"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Dubbele finaliteit"
+                                    },
+                                    "label": "cultuurkuur_dubbele-derdre-finaliteit"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": {
+                                  "nl": "Secundair na Secundair (Se-n-Se)"
+                                },
+                                "label": "cultuurkuur_Secundair-na-secundair-(Se-n-Se)"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Onthaalonderwijs voor anderstalige nieuwkomers (OKAN)"
+                                },
+                                "label": "cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers-OKAN"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Buitengewoon secundair onderwijs"
+                            },
+                            "label": "cultuurkuur_Buitengewoon-secundair-onderwijs"
+                          },
+                          {
+                            "name": {
+                              "nl": "Deeltijds leren en werken"
+                            },
+                            "label": "cultuurkuur_Deeltijds-leren-en-werken"
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Hoger onderwijs"
+                        },
+                        "label": "cultuurkuur_Hoger-onderwijs"
+                      },
+                      {
+                        "name": {
+                          "nl": "Volwassenenonderwijs"
+                        },
+                        "label": "cultuurkuur_Volwassenenonderwijs"
+                      },
+                      {
+                        "name": {
+                          "nl": "Deeltijds kunstonderwijs"
+                        },
+                        "label": "cultuurkuur_Deeltijds-kunstonderwijs-DKO",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Beeldende en audiovisuele kunst"
+                            },
+                            "label": "cultuurkuur_Beeldende-en-audiovisuele-kunst"
+                          },
+                          {
+                            "name": {
+                              "nl": "Dans"
+                            },
+                            "label": "cultuurkuur_dans"
+                          },
+                          {
+                            "name": {
+                              "nl": "Muziek"
+                            },
+                            "label": "cultuurkuur_muziek"
+                          },
+                          {
+                            "name": {
+                              "nl": "Woordkunst & drama"
+                            },
+                            "label": "cultuurkuur_Woordkunst-drama"
                           }
                         ]
                       }
@@ -9777,24 +18090,252 @@
                   "Example 1": {
                     "value": [
                       {
-                        "label": "Basisonderwijs",
-                        "value": "cultuurkuur_basisonderwijs",
+                        "name": {
+                          "nl": "Basisonderwijs"
+                        },
+                        "label": "cultuurkuur_basisonderwijs",
                         "children": [
                           {
-                            "label": "Gewoon basisonderwijs",
-                            "value": "cultuurkuur_Gewoon-basisonderwijs",
+                            "name": {
+                              "nl": "Gewoon basisonderwijs"
+                            },
+                            "label": "cultuurkuur_Gewoon-basisonderwijs",
                             "children": [
                               {
-                                "label": "Gewoon kleuteronderwijs",
-                                "value": "cultuurkuur_Gewoon-kleuteronderwijs",
+                                "name": {
+                                  "nl": "Gewoon kleuteronderwijs"
+                                },
+                                "label": "cultuurkuur_Gewoon-kleuteronderwijs",
                                 "children": [
                                   {
-                                    "label": "Kleuter (2-3 jaar)",
-                                    "value": "cultuurkuur_Kleuter-2-3-jaar"
+                                    "name": {
+                                      "nl": "Kleuter (2-3 jaar)"
+                                    },
+                                    "label": "cultuurkuur_Kleuter-2-3-jaar"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Kleuter (3-4 jaar)"
+                                    },
+                                    "label": "cultuurkuur_Kleuter-3-4-jaar"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Kleuter (4-5 jaar)"
+                                    },
+                                    "label": "cultuurkuur_Kleuter-4-5-jaar"
                                   }
                                 ]
+                              },
+                              {
+                                "name": {
+                                  "nl": "Gewoon lager onderwijs"
+                                },
+                                "label": "cultuurkuur_Gewoon-lager-onderwijs",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "Eerste graad"
+                                    },
+                                    "label": "cultuurkuur_1ste-graad"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Tweede graad"
+                                    },
+                                    "label": "cultuurkuur_2de-graad"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Derde graad"
+                                    },
+                                    "label": "cultuurkuur_3de-graad"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": {
+                                  "nl": "Onthaalonderwijs voor anderstalige nieuwkomers (OKAN)"
+                                },
+                                "label": "cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers (OKAN)"
                               }
                             ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Buitengewoon basisonderwijs"
+                            },
+                            "label": "cultuurkuur_Buitengewoon-basisonderwijs",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Buitengewoon kleuteronderwijs"
+                                },
+                                "label": "cultuurkuur_Buitengewoon-kleuteronderwijs"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Buitengewoon lager onderwijs"
+                                },
+                                "label": "cultuurkuur_Buitengewoon-lager-onderwijs"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Secundair onderwijs"
+                        },
+                        "label": "cultuurkuur_Secundair-onderwijs",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Voltijds gewoon secundair onderwijs"
+                            },
+                            "label": "cultuurkuur_Voltijds-gewoon-secundair-onderwijs",
+                            "children": [
+                              {
+                                "name": {
+                                  "nl": "Eerste graad"
+                                },
+                                "label": "cultuurkuur_eerste-graad",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "A-stroom"
+                                    },
+                                    "label": "cultuurkuur_A-stroom"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "B-stroom"
+                                    },
+                                    "label": "cultuurkuur_B-stroom"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": {
+                                  "nl": "Tweede graad"
+                                },
+                                "label": "cultuurkuur_tweede-graad",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "Finaliteit doorstroom"
+                                    },
+                                    "label": "cultuurkuur_finaliteit-tweede-doorstroom"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Finaliteit arbeidsmarkt"
+                                    },
+                                    "label": "cultuurkuur_finaliteit-tweede-arbeidsmarkt"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Dubbele finaliteit"
+                                    },
+                                    "label": "cultuurkuur_dubbele-tweede-finaliteit"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": {
+                                  "nl": "Derde graad"
+                                },
+                                "label": "cultuurkuur_derde-graad",
+                                "children": [
+                                  {
+                                    "name": {
+                                      "nl": "Finaliteit doorstroom"
+                                    },
+                                    "label": "cultuurkuur_finaliteit-derdre-doorstroom"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Finaliteit arbeidsmarkt"
+                                    },
+                                    "label": "cultuurkuur_finaliteit-derdre-arbeidsmarkt"
+                                  },
+                                  {
+                                    "name": {
+                                      "nl": "Dubbele finaliteit"
+                                    },
+                                    "label": "cultuurkuur_dubbele-derdre-finaliteit"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": {
+                                  "nl": "Secundair na Secundair (Se-n-Se)"
+                                },
+                                "label": "cultuurkuur_Secundair-na-secundair-(Se-n-Se)"
+                              },
+                              {
+                                "name": {
+                                  "nl": "Onthaalonderwijs voor anderstalige nieuwkomers (OKAN)"
+                                },
+                                "label": "cultuurkuur_Onthaalonderwijs-voor-anderstalige-nieuwkomers-OKAN"
+                              }
+                            ]
+                          },
+                          {
+                            "name": {
+                              "nl": "Buitengewoon secundair onderwijs"
+                            },
+                            "label": "cultuurkuur_Buitengewoon-secundair-onderwijs"
+                          },
+                          {
+                            "name": {
+                              "nl": "Deeltijds leren en werken"
+                            },
+                            "label": "cultuurkuur_Deeltijds-leren-en-werken"
+                          }
+                        ]
+                      },
+                      {
+                        "name": {
+                          "nl": "Hoger onderwijs"
+                        },
+                        "label": "cultuurkuur_Hoger-onderwijs"
+                      },
+                      {
+                        "name": {
+                          "nl": "Volwassenenonderwijs"
+                        },
+                        "label": "cultuurkuur_Volwassenenonderwijs"
+                      },
+                      {
+                        "name": {
+                          "nl": "Deeltijds kunstonderwijs"
+                        },
+                        "label": "cultuurkuur_Deeltijds-kunstonderwijs-DKO",
+                        "children": [
+                          {
+                            "name": {
+                              "nl": "Beeldende en audiovisuele kunst"
+                            },
+                            "label": "cultuurkuur_Beeldende-en-audiovisuele-kunst"
+                          },
+                          {
+                            "name": {
+                              "nl": "Dans"
+                            },
+                            "label": "cultuurkuur_dans"
+                          },
+                          {
+                            "name": {
+                              "nl": "Muziek"
+                            },
+                            "label": "cultuurkuur_muziek"
+                          },
+                          {
+                            "name": {
+                              "nl": "Woordkunst & drama"
+                            },
+                            "label": "cultuurkuur_Woordkunst-drama"
                           }
                         ]
                       }
@@ -10042,9 +18583,6 @@
   },
   "tags": [
     {
-      "name": "Cultuurkuur"
-    },
-    {
       "name": "Events"
     },
     {
@@ -10067,6 +18605,9 @@
     },
     {
       "name": "Productions"
+    },
+    {
+      "name": "Taxonomy"
     },
     {
       "name": "Users"

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -9496,6 +9496,308 @@
           }
         ]
       }
+    },
+    "/regions": {
+      "get": {
+        "summary": "/regions",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "content-type": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "application/json"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "children": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "children": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "label": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "x-examples": {
+                    "Example 1": [
+                      {
+                        "label": "Brussels Hoofdstedelijk Gewest",
+                        "value": "nis-01000",
+                        "children": [
+                          {
+                            "label": "Regio Brussel",
+                            "value": "reg-brussel",
+                            "children": [
+                              {
+                                "label": "Anderlecht + deelgemeenten",
+                                "value": "nis-21001"
+                              },
+                              {
+                                "label": "Brussel + deelgemeenten",
+                                "value": "nis-21004"
+                              },
+                              {
+                                "label": "Elsene + deelgemeenten",
+                                "value": "nis-21009"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "label": "Brussels Hoofdstedelijk Gewest",
+                        "value": "nis-01000",
+                        "children": [
+                          {
+                            "label": "Regio Brussel",
+                            "value": "reg-brussel",
+                            "children": [
+                              {
+                                "label": "Anderlecht + deelgemeenten",
+                                "value": "nis-21001"
+                              },
+                              {
+                                "label": "Brussel + deelgemeenten",
+                                "value": "nis-21004"
+                              },
+                              {
+                                "label": "Elsene + deelgemeenten",
+                                "value": "nis-21009"
+                              },
+                              {
+                                "label": "Etterbeek + deelgemeenten",
+                                "value": "nis-21005"
+                              },
+                              {
+                                "label": "Evere + deelgemeenten",
+                                "value": "nis-21006"
+                              },
+                              {
+                                "label": "Ganshoren + deelgemeenten",
+                                "value": "nis-21008"
+                              },
+                              {
+                                "label": "Jette + deelgemeenten",
+                                "value": "nis-21010"
+                              },
+                              {
+                                "label": "Koekelberg + deelgemeenten",
+                                "value": "nis-21011"
+                              },
+                              {
+                                "label": "Oudergem + deelgemeenten",
+                                "value": "nis-21002"
+                              },
+                              {
+                                "label": "Schaarbeek + deelgemeenten",
+                                "value": "nis-21015"
+                              },
+                              {
+                                "label": "Sint-Agatha-Berchem + deelgemeenten",
+                                "value": "nis-21003"
+                              },
+                              {
+                                "label": "Sint-Gillis + deelgemeenten",
+                                "value": "nis-21013"
+                              },
+                              {
+                                "label": "Sint-Jans-Molenbeek + deelgemeenten",
+                                "value": "nis-21012"
+                              },
+                              {
+                                "label": "Sint-Joost-ten-Node + deelgemeenten",
+                                "value": "nis-21014"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-regions",
+        "x-internal": true,
+        "requestBody": {
+          "content": {}
+        },
+        "parameters": [],
+        "description": "Returns a hierarchical list of the regions in Flanders and Brussel. Each level includes a label, value with the NIS-code, and optional nested children, allowing integrators to display lists of all regions and municipalities."
+      }
+    },
+    "/education-levels": {
+      "get": {
+        "summary": "/education-levels",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "content-type": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "application/json"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "children": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "children": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "label": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "x-examples": {
+                    "Example 1": [
+                      {
+                        "label": "Brussels Hoofdstedelijk Gewest",
+                        "value": "nis-01000",
+                        "children": [
+                          {
+                            "label": "Regio Brussel",
+                            "value": "reg-brussel",
+                            "children": [
+                              {
+                                "label": "Anderlecht + deelgemeenten",
+                                "value": "nis-21001"
+                              },
+                              {
+                                "label": "Brussel + deelgemeenten",
+                                "value": "nis-21004"
+                              },
+                              {
+                                "label": "Elsene + deelgemeenten",
+                                "value": "nis-21009"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": [
+                      {
+                        "label": "Basisonderwijs",
+                        "value": "cultuurkuur_basisonderwijs",
+                        "children": [
+                          {
+                            "label": "Gewoon basisonderwijs",
+                            "value": "cultuurkuur_Gewoon-basisonderwijs",
+                            "children": [
+                              {
+                                "label": "Gewoon kleuteronderwijs",
+                                "value": "cultuurkuur_Gewoon-kleuteronderwijs",
+                                "children": [
+                                  {
+                                    "label": "Kleuter (2-3 jaar)",
+                                    "value": "cultuurkuur_Kleuter-2-3-jaar"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-education-levels",
+        "x-internal": true,
+        "requestBody": {
+          "content": {}
+        },
+        "parameters": [],
+        "description": "Returns a hierarchical list of education levels used on Cultuurkuur. Each level includes a label, value, and optional nested children, allowing integrators to display or process education structures ranging from early childhood to higher education."
+      }
     }
   },
   "components": {


### PR DESCRIPTION
### Added

- Add 2 new internal endpoints, /regions and /educational-levels, meant for the new Cultuurkuur flow

### Related pr
- https://github.com/cultuurnet/udb3-backend/pull/2047


---

Ticket: https://jira.uitdatabank.be/browse/III-6579 
