### PR TITLE
III-6733 Error response body not working for anonymous users

### DIFF
--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -18557,7 +18557,7 @@
   "components": {
     "schemas": {
       "Error": {
-        "$ref": "https://raw.githubusercontent.com/cultuurnet/apidocs/main/projects/errors/models/Error.json",
+        "$ref": "https://raw.githubusercontent.com/cultuurnet/apidocs/main/projects/errors/models/Error.json"
       }
     },
     "securitySchemes": {

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -18558,7 +18558,6 @@
     "schemas": {
       "Error": {
         "$ref": "https://raw.githubusercontent.com/cultuurnet/apidocs/main/projects/errors/models/Error.json",
-        "x-internal": true
       }
     },
     "securitySchemes": {

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -1049,8 +1049,7 @@
   "components": {
     "schemas": {
       "Error": {
-        "$ref": "https://raw.githubusercontent.com/cultuurnet/apidocs/main/projects/errors/models/Error.json",
-        "x-internal": true
+        "$ref": "https://raw.githubusercontent.com/cultuurnet/apidocs/main/projects/errors/models/Error.json"
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
### Changed

- `projects/uitdatabank/reference/entry.json`: Don't make `errors` internal.
- `projects/uitdatabank/reference/search.json`: Don't make `errors` internal.

### Fixed

- Anonymous users should no longer see an error, when they want to see the response body for `4XX`

---

Ticket: https://jira.publiq.be/browse/III-6733
