### PR TITLE
III-7108: Add overnight boolean property to subEvents

### DIFF
--- a/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
+++ b/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
@@ -186,6 +186,13 @@ Events of type "Kamp of vakantie" (term id `0.57.0.0.0`) can optionally include 
 
 ```json
 {
+  "terms": [
+    {
+      "id": "0.57.0.0.0",
+      "label": "Kamp of vakantie",
+      "domain": "eventtype"
+    }
+  ],
   "calendarType": "multiple",
   "subEvent": [
     {
@@ -203,7 +210,7 @@ Events of type "Kamp of vakantie" (term id `0.57.0.0.0`) can optionally include 
 
 **Validation rules:**
 
-* `overnight` can only be set when the event has at least one term with id `0.57.0.0.0`. Matching is done on the term id, not the label, because labels can be translated.
+* `overnight` can only be set when the event has at least one term with id `0.57.0.0.0`. 
 * `overnight` is optional and defaults to `false` when omitted.
 * When the term `0.57.0.0.0` is removed from the event, `overnight` is automatically reset to `false` on all subEvents.
 

--- a/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
+++ b/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
@@ -180,6 +180,37 @@ For periodic/permanent calendar types:
 * `childcare.end` must be **later** than `closes`. For example, if `closes` is `17:00`, `childcare.end` must be after `17:00`.
 * These rules are also enforced when updating `opens` or `closes` on an existing item that already has childcare times set.
 
+### Overnight (events only, single/multiple)
+
+Events of type "Kamp of vakantie" (term id `0.57.0.0.0`) can optionally include an `overnight` boolean on each `subEvent` to indicate whether that occurrence involves an overnight stay.
+
+```json
+{
+  "calendarType": "multiple",
+  "subEvent": [
+    {
+      "startDate": "2026-07-01T09:00:00+02:00",
+      "endDate": "2026-07-05T17:00:00+02:00",
+      "overnight": true
+    },
+    {
+      "startDate": "2026-07-08T09:00:00+02:00",
+      "endDate": "2026-07-12T17:00:00+02:00"
+    }
+  ]
+}
+```
+
+**Validation rules:**
+
+* `overnight` can only be set when the event has at least one term with id `0.57.0.0.0`. Matching is done on the term id, not the label, because labels can be translated.
+* `overnight` is optional and defaults to `false` when omitted.
+* When the term `0.57.0.0.0` is removed from the event, `overnight` is automatically reset to `false` on all subEvents.
+
+**API behavior:**
+
+In the read model (GET), `overnight` is only included in the subEvent object when its value is `true`. When `false`, the property is omitted from the response.
+
 ### periodic/permanent
 
 When creating or updating an event or place with calendarType `periodic`, you must include `startDate` and `endDate` properties that define the period during which the event or place are scheduled. Additionally, you can include an optional `openingHours` property to indicate on which (recurring) weekdays the event or place is available.

--- a/projects/uitdatabank/models/event-subEvent-patch.json
+++ b/projects/uitdatabank/models/event-subEvent-patch.json
@@ -12,7 +12,8 @@
         "childcare": {
           "start": "08:00",
           "end": "23:00"
-        }
+        },
+        "overnight": true
       }
     ],
     [
@@ -140,6 +141,11 @@
       },
       "bookingInfo": {
         "$ref": "./event-bookingInfo.json"
+      },
+      "overnight": {
+        "type": "boolean",
+        "description": "Indicates whether this occurrence involves an overnight stay. Only accepted when the event has a term with id `0.57.0.0.0` (\"Kamp of vakantie\"). Defaults to `false` when omitted. Automatically reset to `false` when term `0.57.0.0.0` is removed from the event.",
+        "example": true
       }
     },
     "required": [

--- a/projects/uitdatabank/models/event-subEvent-put.json
+++ b/projects/uitdatabank/models/event-subEvent-put.json
@@ -17,7 +17,8 @@
         "bookingAvailability": {
           "type": "Available",
           "capacity": 100
-        }
+        },
+        "overnight": true
       }
     ],
     [
@@ -72,6 +73,11 @@
       },
       "bookingInfo": {
         "$ref": "./event-bookingInfo.json"
+      },
+      "overnight": {
+        "type": "boolean",
+        "description": "Indicates whether this occurrence involves an overnight stay. Only accepted when the event has a term with id `0.57.0.0.0` (\"Kamp of vakantie\"). Defaults to `false` when omitted. Automatically reset to `false` when term `0.57.0.0.0` is removed from the event.",
+        "example": true
       }
     },
     "required": [

--- a/projects/uitdatabank/models/event-subEvent.json
+++ b/projects/uitdatabank/models/event-subEvent.json
@@ -19,7 +19,8 @@
           "type": "Available",
           "capacity": 100,
           "remainingCapacity": 25
-        }
+        },
+        "overnight": true
       }
     ],
     [
@@ -81,6 +82,11 @@
       },
       "bookingInfo": {
         "$ref": "./event-bookingInfo.json"
+      },
+      "overnight": {
+        "type": "boolean",
+        "description": "Indicates whether this occurrence involves an overnight stay. Only present in the response when `true`. Only applicable when the event has a term with id `0.57.0.0.0` (\"Kamp of vakantie\").",
+        "example": true
       }
     },
     "required": [


### PR DESCRIPTION
## Summary

- Adds optional `overnight` boolean to subEvents for `calendarType` `single` and `multiple`
- Only accepted when term `0.57.0.0.0` ("Kamp of vakantie") is present on the event (matched on id, not label)
- Omitted from GET responses when `false`; auto-reset to `false` when the term is removed
- Updated examples in all three subEvent schema files (`event-subEvent.json`, `event-subEvent-put.json`, `event-subEvent-patch.json`)
- Added new "Overnight" section in `calendar-info.md`

## Ticket
https://jira.publiq.be/browse/III-7108