### PR TITLE
III-7136 Add openingHoursClosedDays and openingHoursAdjustedDays to places

### DIFF
--- a/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
+++ b/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
@@ -371,8 +371,8 @@ For events, each opening hours item in `openingHoursAdjustedDays` can optionally
 
 ```json
 {
-  "startDate": "2026-12-21T00:00:00+01:00",
-  "endDate": "2026-12-30T23:00:00+01:00",
+  "startDate": "2026-12-21",
+  "endDate": "2026-12-30",
   "description": {
     "nl": "Kerstvakantie"
   },

--- a/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
+++ b/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
@@ -278,9 +278,9 @@ When creating or updating an event or place with calendarType `permanent` you do
 }
 ```
 
-## Adjusted closed days (events only, periodic/permanent)
+## Adjusted closed days (periodic/permanent)
 
-Events with calendarType `periodic` or `permanent` can optionally include an `openingHoursClosedDays` array to mark specific date ranges as closed, overriding the default opening hours for those dates. This property is not available for places.
+Events and places with calendarType `periodic` or `permanent` can optionally include an `openingHoursClosedDays` array to mark specific date ranges as closed, overriding the default opening hours for those dates.
 
 ```json
 {
@@ -300,11 +300,11 @@ Events with calendarType `periodic` or `permanent` can optionally include an `op
 }
 ```
 
-Each entry defines a date range during which the event is considered closed. The `description` property is optional and translatable.
+Each entry defines a date range during which the event or place is considered closed. The `description` property is optional and translatable.
 
 **Validation rules:**
 
-* For `periodic` events: all exception dates must fall within the main `startDate` and `endDate` of the event.
+* For `periodic` events and places: all exception dates must fall within the main `startDate` and `endDate`.
 * `startDate` must be on or before `endDate`.
 
 **Overwriting or clearing closed days:**
@@ -319,9 +319,9 @@ Each `openingHoursClosedDays` array is independent: omitting the property preser
 
 GET endpoints return `openingHoursClosedDays` sorted by `startDate`.
 
-## Adjusted opening hours (events only, periodic/permanent)
+## Adjusted opening hours (periodic/permanent)
 
-Events with calendarType `periodic` or `permanent` can optionally include an `openingHoursAdjustedDays` array to define temporary custom opening hours that override the default schedule for specific date ranges. This property is not available for places.
+Events and places with calendarType `periodic` or `permanent` can optionally include an `openingHoursAdjustedDays` array to define temporary custom opening hours that override the default schedule for specific date ranges.
 
 ```json
 {
@@ -367,7 +367,7 @@ Events with calendarType `periodic` or `permanent` can optionally include an `op
 
 Each entry defines a date range during which the specified `openingHours` replace the default schedule. The `description` property is optional and translatable.
 
-Like regular opening hours, each opening hours item in `openingHoursAdjustedDays` can optionally include `childcare` information to specify adjusted childcare availability times for that period:
+For events, each opening hours item in `openingHoursAdjustedDays` can optionally include `childcare` information to specify adjusted childcare availability times for that period:
 
 ```json
 {
@@ -396,16 +396,16 @@ Like regular opening hours, each opening hours item in `openingHoursAdjustedDays
 
 **Validation rules:**
 
-* For `periodic` events: all adjusted dates must fall within the main `startDate` and `endDate` of the event.
+* For `periodic` events and places: all adjusted dates must fall within the main `startDate` and `endDate`.
 * `startDate` must be on or before `endDate`.
 * No overlaps are allowed between entries in `openingHoursAdjustedDays`.
 * Description has a maximum length of 1000 characters per language.
-* Childcare validation rules apply to adjusted opening hours: `childcare.start` must be earlier than `opens`, and `childcare.end` must be later than `closes` on each opening hours item.
+* For events: childcare validation rules apply to adjusted opening hours: `childcare.start` must be earlier than `opens`, and `childcare.end` must be later than `closes` on each opening hours item.
 
 **Interaction with closed days:**
 
 When `openingHoursClosedDays` and `openingHoursAdjustedDays` overlap, `openingHoursClosedDays` always take precedence. This means:
-* If a date is marked as closed in `openingHoursClosedDays`, the event is closed for that entire date, regardless of what `openingHoursAdjustedDays` specifies.
+* If a date is marked as closed in `openingHoursClosedDays`, the event or place is closed for that entire date, regardless of what `openingHoursAdjustedDays` specifies.
 * Use `openingHoursClosedDays` for holidays and closures.
 * Use `openingHoursAdjustedDays` for periods with modified (but non-zero) opening hours.
 

--- a/projects/uitdatabank/models/common-openingHoursAdjustedDays.json
+++ b/projects/uitdatabank/models/common-openingHoursAdjustedDays.json
@@ -1,0 +1,78 @@
+{
+  "description": "List of specific date ranges during which custom opening hours override the default schedule. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set adjusted opening hours.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "startDate": {
+        "type": "string",
+        "format": "date",
+        "description": "Start of the adjusted opening hours date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic events and places, must fall within the main startDate/endDate.",
+        "examples": ["2026-12-21"]
+      },
+      "endDate": {
+        "type": "string",
+        "format": "date",
+        "description": "End of the adjusted opening hours date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic events and places, this must be on or after startDate, and within the main startDate/endDate. When openingHoursClosedDays overlap with this range, the closed days take precedence.",
+        "examples": ["2027-01-03"]
+      },
+      "description": {
+        "description": "Optional human-readable description of the adjusted opening hours period, as localized text. Maximum 1000 characters per language.",
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": false,
+        "properties": {
+          "nl": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "Dutch description." },
+          "fr": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "French description." },
+          "de": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "German description." },
+          "en": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "English description." }
+        }
+      }
+    },
+    "required": ["startDate", "endDate", "openingHours"],
+    "examples": [
+      {
+        "startDate": "2026-12-21",
+        "endDate": "2026-12-30",
+        "description": {
+          "nl": "Kerstvakantie",
+          "fr": "fêtes de Noël"
+        },
+        "openingHours": [
+          {
+            "opens": "13:00",
+            "closes": "15:00",
+            "dayOfWeek": [
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "examples": [
+    [
+      {
+        "startDate": "2026-12-21",
+        "endDate": "2026-12-30",
+        "description": {
+          "nl": "Kerstvakantie",
+          "fr": "fêtes de Noël"
+        },
+        "openingHours": [
+          {
+            "opens": "13:00",
+            "closes": "15:00",
+            "dayOfWeek": [
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        ]
+      }
+    ]
+  ]
+}

--- a/projects/uitdatabank/models/common-openingHoursAdjustedDays.json
+++ b/projects/uitdatabank/models/common-openingHoursAdjustedDays.json
@@ -1,5 +1,5 @@
 {
-  "title": "openingHoursAdjustedDays",
+  "title": "common.openingHoursAdjustedDays",
   "description": "List of specific date ranges during which custom opening hours override the default schedule. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set adjusted opening hours.",
   "type": "array",
   "items": {

--- a/projects/uitdatabank/models/common-openingHoursAdjustedDays.json
+++ b/projects/uitdatabank/models/common-openingHoursAdjustedDays.json
@@ -28,6 +28,12 @@
           "de": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "German description." },
           "en": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "English description." }
         }
+      },
+      "openingHours": {
+        "allOf": [
+          { "$ref": "./common-openingHours.json" },
+          { "minItems": 1 }
+        ]
       }
     },
     "required": ["startDate", "endDate", "openingHours"],

--- a/projects/uitdatabank/models/common-openingHoursAdjustedDays.json
+++ b/projects/uitdatabank/models/common-openingHoursAdjustedDays.json
@@ -1,4 +1,5 @@
 {
+  "title": "openingHoursAdjustedDays",
   "description": "List of specific date ranges during which custom opening hours override the default schedule. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set adjusted opening hours.",
   "type": "array",
   "items": {

--- a/projects/uitdatabank/models/common-openingHoursClosedDays.json
+++ b/projects/uitdatabank/models/common-openingHoursClosedDays.json
@@ -1,6 +1,6 @@
 {
-  "title": "event.openingHoursClosedDays",
-  "description": "List of specific date ranges during which the event is considered closed, overriding the default opening hours. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set closed days.",
+  "title": "openingHoursClosedDays",
+  "description": "List of specific date ranges during which the event or place is considered closed, overriding the default opening hours. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set closed days.",
   "type": "array",
   "items": {
     "type": "object",
@@ -8,13 +8,13 @@
       "startDate": {
         "type": "string",
         "format": "date",
-        "description": "Start of the closed date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic events, must fall within the main startDate/endDate of the event.",
+        "description": "Start of the closed date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic events and places, must fall within the main startDate/endDate.",
         "examples": ["2026-04-06"]
       },
       "endDate": {
         "type": "string",
         "format": "date",
-        "description": "End of the closed date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic events, this must be on or after startDate, and within the main startDate/endDate.",
+        "description": "End of the closed date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic events and places, this must be on or after startDate, and within the main startDate/endDate.",
         "examples": ["2026-04-06"]
       },
       "description": {

--- a/projects/uitdatabank/models/common-openingHoursClosedDays.json
+++ b/projects/uitdatabank/models/common-openingHoursClosedDays.json
@@ -1,5 +1,5 @@
 {
-  "title": "openingHoursClosedDays",
+  "title": "common.openingHoursClosedDays",
   "description": "List of specific date ranges during which the event or place is considered closed, overriding the default opening hours. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set closed days.",
   "type": "array",
   "items": {

--- a/projects/uitdatabank/models/event-calendar-put.json
+++ b/projects/uitdatabank/models/event-calendar-put.json
@@ -21,7 +21,7 @@
           "$ref": "./event-openingHours.json"
         },
         "openingHoursClosedDays": {
-          "$ref": "./event-openingHoursClosedDays.json"
+          "$ref": "./common-openingHoursClosedDays.json"
         },
         "openingHoursAdjustedDays": {
           "$ref": "./event-openingHoursAdjustedDays.json"

--- a/projects/uitdatabank/models/event-openingHoursAdjustedDays.json
+++ b/projects/uitdatabank/models/event-openingHoursAdjustedDays.json
@@ -1,85 +1,18 @@
 {
   "title": "event.openingHoursAdjustedDays",
-  "description": "List of specific date ranges during which custom opening hours override the default schedule. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set adjusted opening hours.",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "properties": {
-      "startDate": {
-        "type": "string",
-        "format": "date",
-        "description": "Start of the adjusted opening hours date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic events, must fall within the main startDate/endDate of the event.",
-        "examples": ["2026-12-21"]
-      },
-      "endDate": {
-        "type": "string",
-        "format": "date",
-        "description": "End of the adjusted opening hours date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic events, this must be on or after startDate, and within the main startDate/endDate. When openingHoursClosedDays overlap with this range, the closed days take precedence.",
-        "examples": ["2027-01-03"]
-      },
-      "description": {
-        "description": "Optional human-readable description of the adjusted opening hours period, as localized text. Maximum 1000 characters per language.",
-        "type": "object",
-        "minProperties": 1,
-        "additionalProperties": false,
+  "allOf": [
+    { "$ref": "./common-openingHoursAdjustedDays.json" },
+    {
+      "items": {
         "properties": {
-          "nl": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "Dutch description." },
-          "fr": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "French description." },
-          "de": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "German description." },
-          "en": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "English description." }
+          "openingHours": {
+            "allOf": [
+              { "$ref": "./event-openingHours.json" },
+              { "minItems": 1 }
+            ]
+          }
         }
-      },
-      "openingHours": {
-        "allOf": [
-          { "$ref": "./event-openingHours.json" },
-          { "minItems": 1 }
-        ]
       }
-    },
-    "required": ["startDate", "endDate", "openingHours"],
-    "examples": [
-      {
-        "startDate": "2026-12-21",
-        "endDate": "2026-12-30",
-        "description": {
-          "nl": "Kerstvakantie",
-          "fr": "fêtes de Noël"
-        },
-        "openingHours": [
-          {
-            "opens": "13:00",
-            "closes": "15:00",
-            "dayOfWeek": [
-              "friday",
-              "saturday",
-              "sunday"
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  "examples": [
-    [
-      {
-        "startDate": "2026-12-21",
-        "endDate": "2026-12-30",
-        "description": {
-          "nl": "Kerstvakantie",
-          "fr": "fêtes de Noël"
-        },
-        "openingHours": [
-          {
-            "opens": "13:00",
-            "closes": "15:00",
-            "dayOfWeek": [
-              "friday",
-              "saturday",
-              "sunday"
-            ]
-          }
-        ]
-      }
-    ]
+    }
   ]
 }

--- a/projects/uitdatabank/models/event-openingHoursAdjustedDays.json
+++ b/projects/uitdatabank/models/event-openingHoursAdjustedDays.json
@@ -14,5 +14,32 @@
         }
       }
     }
+  ],
+  "examples": [
+    [
+      {
+        "startDate": "2026-12-21",
+        "endDate": "2026-12-30",
+        "description": {
+          "nl": "Kerstvakantie",
+          "fr": "fêtes de Noël"
+        },
+        "openingHours": [
+          {
+            "opens": "13:00",
+            "closes": "15:00",
+            "childcare": {
+              "start": "12:00",
+              "end": "16:00"
+            },
+            "dayOfWeek": [
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        ]
+      }
+    ]
   ]
 }

--- a/projects/uitdatabank/models/event.json
+++ b/projects/uitdatabank/models/event.json
@@ -45,7 +45,7 @@
           "$ref": "./event-openingHours.json"
         },
         "openingHoursClosedDays": {
-          "$ref": "./event-openingHoursClosedDays.json"
+          "$ref": "./common-openingHoursClosedDays.json"
         },
         "openingHoursAdjustedDays": {
           "$ref": "./event-openingHoursAdjustedDays.json"

--- a/projects/uitdatabank/models/place-calendar-put.json
+++ b/projects/uitdatabank/models/place-calendar-put.json
@@ -15,6 +15,12 @@
     "openingHours": {
       "$ref": "./place-openingHours.json"
     },
+    "openingHoursClosedDays": {
+      "$ref": "./common-openingHoursClosedDays.json"
+    },
+    "openingHoursAdjustedDays": {
+      "$ref": "./place-openingHoursAdjustedDays.json"
+    },
     "startDate": {
       "$ref": "./place-startDate.json"
     },

--- a/projects/uitdatabank/models/place-openingHoursAdjustedDays.json
+++ b/projects/uitdatabank/models/place-openingHoursAdjustedDays.json
@@ -1,0 +1,85 @@
+{
+  "title": "place.openingHoursAdjustedDays",
+  "description": "List of specific date ranges during which custom opening hours override the default schedule. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set adjusted opening hours.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "startDate": {
+        "type": "string",
+        "format": "date",
+        "description": "Start of the adjusted opening hours date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic places, must fall within the main startDate/endDate.",
+        "examples": ["2026-12-21"]
+      },
+      "endDate": {
+        "type": "string",
+        "format": "date",
+        "description": "End of the adjusted opening hours date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic places, this must be on or after startDate, and within the main startDate/endDate. When openingHoursClosedDays overlap with this range, the closed days take precedence.",
+        "examples": ["2027-01-03"]
+      },
+      "description": {
+        "description": "Optional human-readable description of the adjusted opening hours period, as localized text. Maximum 1000 characters per language.",
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": false,
+        "properties": {
+          "nl": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "Dutch description." },
+          "fr": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "French description." },
+          "de": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "German description." },
+          "en": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "English description." }
+        }
+      },
+      "openingHours": {
+        "allOf": [
+          { "$ref": "./place-openingHours.json" },
+          { "minItems": 1 }
+        ]
+      }
+    },
+    "required": ["startDate", "endDate", "openingHours"],
+    "examples": [
+      {
+        "startDate": "2026-12-21",
+        "endDate": "2026-12-30",
+        "description": {
+          "nl": "Kerstvakantie",
+          "fr": "fêtes de Noël"
+        },
+        "openingHours": [
+          {
+            "opens": "13:00",
+            "closes": "15:00",
+            "dayOfWeek": [
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "examples": [
+    [
+      {
+        "startDate": "2026-12-21",
+        "endDate": "2026-12-30",
+        "description": {
+          "nl": "Kerstvakantie",
+          "fr": "fêtes de Noël"
+        },
+        "openingHours": [
+          {
+            "opens": "13:00",
+            "closes": "15:00",
+            "dayOfWeek": [
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        ]
+      }
+    ]
+  ]
+}

--- a/projects/uitdatabank/models/place-openingHoursAdjustedDays.json
+++ b/projects/uitdatabank/models/place-openingHoursAdjustedDays.json
@@ -1,85 +1,18 @@
 {
   "title": "place.openingHoursAdjustedDays",
-  "description": "List of specific date ranges during which custom opening hours override the default schedule. Only applicable for calendarType `periodic` and `permanent`. An empty array clears all previously set adjusted opening hours.",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "properties": {
-      "startDate": {
-        "type": "string",
-        "format": "date",
-        "description": "Start of the adjusted opening hours date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic places, must fall within the main startDate/endDate.",
-        "examples": ["2026-12-21"]
-      },
-      "endDate": {
-        "type": "string",
-        "format": "date",
-        "description": "End of the adjusted opening hours date range (inclusive), in ISO 8601 date format (YYYY-MM-DD). For periodic places, this must be on or after startDate, and within the main startDate/endDate. When openingHoursClosedDays overlap with this range, the closed days take precedence.",
-        "examples": ["2027-01-03"]
-      },
-      "description": {
-        "description": "Optional human-readable description of the adjusted opening hours period, as localized text. Maximum 1000 characters per language.",
-        "type": "object",
-        "minProperties": 1,
-        "additionalProperties": false,
+  "allOf": [
+    { "$ref": "./common-openingHoursAdjustedDays.json" },
+    {
+      "items": {
         "properties": {
-          "nl": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "Dutch description." },
-          "fr": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "French description." },
-          "de": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "German description." },
-          "en": { "type": "string", "maxLength": 1000, "minLength": 1, "description": "English description." }
+          "openingHours": {
+            "allOf": [
+              { "$ref": "./place-openingHours.json" },
+              { "minItems": 1 }
+            ]
+          }
         }
-      },
-      "openingHours": {
-        "allOf": [
-          { "$ref": "./place-openingHours.json" },
-          { "minItems": 1 }
-        ]
       }
-    },
-    "required": ["startDate", "endDate", "openingHours"],
-    "examples": [
-      {
-        "startDate": "2026-12-21",
-        "endDate": "2026-12-30",
-        "description": {
-          "nl": "Kerstvakantie",
-          "fr": "fêtes de Noël"
-        },
-        "openingHours": [
-          {
-            "opens": "13:00",
-            "closes": "15:00",
-            "dayOfWeek": [
-              "friday",
-              "saturday",
-              "sunday"
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  "examples": [
-    [
-      {
-        "startDate": "2026-12-21",
-        "endDate": "2026-12-30",
-        "description": {
-          "nl": "Kerstvakantie",
-          "fr": "fêtes de Noël"
-        },
-        "openingHours": [
-          {
-            "opens": "13:00",
-            "closes": "15:00",
-            "dayOfWeek": [
-              "friday",
-              "saturday",
-              "sunday"
-            ]
-          }
-        ]
-      }
-    ]
+    }
   ]
 }

--- a/projects/uitdatabank/models/place-with-read-example.json
+++ b/projects/uitdatabank/models/place-with-read-example.json
@@ -42,8 +42,8 @@
         "longitude": 4.7137986
       },
       "calendarType": "periodic",
-      "startDate": "2021-05-17T22:00:00+00:00",
-      "endDate": "2021-05-17T22:00:00+00:00",
+      "startDate": "2026-01-01T00:00:00+01:00",
+      "endDate": "2026-12-31T23:59:59+01:00",
       "status": {
         "type": "Available",
         "reason": {

--- a/projects/uitdatabank/models/place-with-read-example.json
+++ b/projects/uitdatabank/models/place-with-read-example.json
@@ -62,6 +62,37 @@
           ]
         }
       ],
+      "openingHoursClosedDays": [
+        {
+          "startDate": "2026-04-06",
+          "endDate": "2026-04-06",
+          "description": {
+            "nl": "Paasmaandag",
+            "fr": "Lundi de Pâques"
+          }
+        }
+      ],
+      "openingHoursAdjustedDays": [
+        {
+          "startDate": "2026-12-21",
+          "endDate": "2026-12-30",
+          "description": {
+            "nl": "Kerstvakantie",
+            "fr": "fêtes de Noël"
+          },
+          "openingHours": [
+            {
+              "opens": "13:00",
+              "closes": "15:00",
+              "dayOfWeek": [
+                "friday",
+                "saturday",
+                "sunday"
+              ]
+            }
+          ]
+        }
+      ],
       "availableFrom": "2021-05-17T22:00:00+00:00",
       "availableTo": "2021-05-17T22:00:00+00:00",
       "sameAs": [

--- a/projects/uitdatabank/models/place-with-read-example.json
+++ b/projects/uitdatabank/models/place-with-read-example.json
@@ -93,8 +93,8 @@
           ]
         }
       ],
-      "availableFrom": "2021-05-17T22:00:00+00:00",
-      "availableTo": "2021-05-17T22:00:00+00:00",
+      "availableFrom": "2026-01-01T00:00:00+01:00",
+      "availableTo": "2026-12-31T23:59:59+01:00",
       "sameAs": [
         "http://www.uitinvlaanderen.be/agenda/e/test-place/85b04295-479c-40f5-b3dd-469dfb4387b3"
       ],

--- a/projects/uitdatabank/models/place.json
+++ b/projects/uitdatabank/models/place.json
@@ -41,6 +41,12 @@
         "openingHours": {
           "$ref": "./place-openingHours.json"
         },
+        "openingHoursClosedDays": {
+          "$ref": "./common-openingHoursClosedDays.json"
+        },
+        "openingHoursAdjustedDays": {
+          "$ref": "./place-openingHoursAdjustedDays.json"
+        },
         "availableFrom": {
           "$ref": "./place-availableFrom.json"
         },


### PR DESCRIPTION
## Summary

- Renames `event-openingHoursClosedDays.json` → `common-openingHoursClosedDays.json` since the schema is identical for events and places (no childcare involved)
- Adds `place-openingHoursAdjustedDays.json` that mirrors the event version but uses `place-openingHours.json` (no childcare support)
- Adds `openingHoursClosedDays` and `openingHoursAdjustedDays` to `place.json` and `place-calendar-put.json`
- Updates `place-with-read-example.json` with example values for both new properties
- Updates `calendar-info.md` to remove "events only" restrictions; clarifies childcare within adjusted opening hours remains events-only

## Test plan

- [ ] Verify `place.json` and `place-calendar-put.json` expose both new properties
- [ ] Verify `event.json` and `event-calendar-put.json` still resolve correctly (now pointing to `common-openingHoursClosedDays.json`)
- [ ] Verify `place-openingHoursAdjustedDays.json` does not allow `childcare` (uses `place-openingHours.json`)
- [ ] Verify `event-openingHoursAdjustedDays.json` still allows `childcare` (uses `event-openingHours.json`)
- [ ] Check docs render correctly in `calendar-info.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ticket https://jira.publiq.be/browse/III-7136