### PR TITLE
III-7108 Add overnight to event read model example

### DIFF
--- a/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
+++ b/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
@@ -182,12 +182,7 @@ For periodic/permanent calendar types:
 
 ### Overnight (events only, single/multiple)
 
-Events of type "Kamp of vakantie" (term id `0.57.0.0.0`) can optionally include an `overnight` boolean on each `subEvent` to indicate whether that occurrence involves an overnight stay.
-
-The `overnight` property is accepted on subEvents in:
-
-* `PUT /events/{eventId}/calendar`
-* `PATCH /events/{eventId}/subEvents`
+Events of type "Kamp of vakantie" (term id `0.57.0.0.0`) can optionally include an `overnight` boolean on each `subEvent` to indicate whether that occurrence involves an overnight stay. In the read model (GET), `overnight` is only included in the subEvent object when its value is `true`. When `false`, the property is omitted from the response entirely.
 
 For example, when creating or replacing the calendar via `PUT /events/{eventId}/calendar`:
 
@@ -228,14 +223,9 @@ To update `overnight` on an individual subEvent without replacing the full calen
 
 **Validation rules:**
 
-* `overnight` can only be set when the event has at least one term with id `0.57.0.0.0`. The match is done on the term `id`, not the `label`, because labels can be translated. Sending `overnight: true` on an event without this term returns a `400` error.
+* `overnight` can only be set when the event has at least one term with id `0.57.0.0.0`.  Sending `overnight: true` on an event without this term returns a `400` error.
 * `overnight` is optional and defaults to `false` when omitted.
 * `overnight` is only valid for `calendarType: single` or `calendarType: multiple`. Sending it for `periodic` or `permanent` events (which have no subEvents) returns a `400` error.
-* When the term `0.57.0.0.0` is removed from the event via `PUT` or `PATCH` on the `terms` property, `overnight` is automatically reset to `false` on all subEvents.
-
-**API behavior:**
-
-In the read model (GET), `overnight` is only included in the subEvent object when its value is `true`. When `false`, the property is omitted from the response entirely.
 
 ### periodic/permanent
 

--- a/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
+++ b/projects/uitdatabank/docs/entry-api/shared/calendar-info.md
@@ -184,6 +184,13 @@ For periodic/permanent calendar types:
 
 Events of type "Kamp of vakantie" (term id `0.57.0.0.0`) can optionally include an `overnight` boolean on each `subEvent` to indicate whether that occurrence involves an overnight stay.
 
+The `overnight` property is accepted on subEvents in:
+
+* `PUT /events/{eventId}/calendar`
+* `PATCH /events/{eventId}/subEvents`
+
+For example, when creating or replacing the calendar via `PUT /events/{eventId}/calendar`:
+
 ```json
 {
   "terms": [
@@ -208,15 +215,27 @@ Events of type "Kamp of vakantie" (term id `0.57.0.0.0`) can optionally include 
 }
 ```
 
+To update `overnight` on an individual subEvent without replacing the full calendar, use `PATCH /events/{eventId}/subEvents` and reference the subEvent by its `id`:
+
+```json
+[
+  {
+    "id": 0,
+    "overnight": true
+  }
+]
+```
+
 **Validation rules:**
 
-* `overnight` can only be set when the event has at least one term with id `0.57.0.0.0`. 
+* `overnight` can only be set when the event has at least one term with id `0.57.0.0.0`. The match is done on the term `id`, not the `label`, because labels can be translated. Sending `overnight: true` on an event without this term returns a `400` error.
 * `overnight` is optional and defaults to `false` when omitted.
-* When the term `0.57.0.0.0` is removed from the event, `overnight` is automatically reset to `false` on all subEvents.
+* `overnight` is only valid for `calendarType: single` or `calendarType: multiple`. Sending it for `periodic` or `permanent` events (which have no subEvents) returns a `400` error.
+* When the term `0.57.0.0.0` is removed from the event via `PUT` or `PATCH` on the `terms` property, `overnight` is automatically reset to `false` on all subEvents.
 
 **API behavior:**
 
-In the read model (GET), `overnight` is only included in the subEvent object when its value is `true`. When `false`, the property is omitted from the response.
+In the read model (GET), `overnight` is only included in the subEvent object when its value is `true`. When `false`, the property is omitted from the response entirely.
 
 ### periodic/permanent
 

--- a/projects/uitdatabank/models/event-with-read-example.json
+++ b/projects/uitdatabank/models/event-with-read-example.json
@@ -512,6 +512,73 @@
       "completedLanguages": [
         "nl"
       ]
+    },
+    {
+      "@id": "https://io-test.uitdatabank.be/events/b7d5e938-8f0a-53bc-c2g1-f45678901bcd",
+      "mainLanguage": "nl",
+      "name": {
+        "nl": "Zomerkamp 2026"
+      },
+      "calendarType": "multiple",
+      "startDate": "2026-07-01T09:00:00+02:00",
+      "endDate": "2026-07-12T17:00:00+02:00",
+      "subEvent": [
+        {
+          "id": 0,
+          "startDate": "2026-07-01T09:00:00+02:00",
+          "endDate": "2026-07-05T17:00:00+02:00",
+          "status": {
+            "type": "Available"
+          },
+          "bookingAvailability": {
+            "type": "Available"
+          },
+          "overnight": true
+        },
+        {
+          "id": 1,
+          "startDate": "2026-07-08T09:00:00+02:00",
+          "endDate": "2026-07-12T17:00:00+02:00",
+          "status": {
+            "type": "Available"
+          },
+          "bookingAvailability": {
+            "type": "Available"
+          }
+        }
+      ],
+      "location": {
+        "@id": "https://io-test.uitdatabank.be/places/85b04295-479c-40f5-b3dd-469dfb4387b3"
+      },
+      "organizer": {
+        "@id": "https://io-test.uitdatabank.be/organizers/c76db023-ef6d-49d9-8d15-5ddc3e6eb0a9"
+      },
+      "terms": [
+        {
+          "id": "0.57.0.0.0",
+          "label": "Kamp of vakantie",
+          "domain": "eventtype"
+        }
+      ],
+      "audience": {
+        "audienceType": "childrenOnly"
+      },
+      "status": {
+        "type": "Available"
+      },
+      "bookingAvailability": {
+        "type": "Available"
+      },
+      "created": "2026-06-01T10:00:00+02:00",
+      "modified": "2026-06-01T10:00:00+02:00",
+      "creator": "auth0|45c0d021-c78f-445f-adef-be3355b23e4f",
+      "workflowStatus": "DRAFT",
+      "languages": [
+        "nl"
+      ],
+      "completedLanguages": [
+        "nl"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Added

Adds a new field called "overnight" on calendars with type "single" or "multiple".