### PR TITLE
III-7070 Made hour/minute regex more strict

### DIFF
--- a/projects/uitdatabank/models/common-openingHours.json
+++ b/projects/uitdatabank/models/common-openingHours.json
@@ -24,7 +24,7 @@
         "examples": [
           "17:00"
         ],
-        "pattern": "^\\d?\\d:\\d\\d$"
+        "pattern": "^([01]?\\d|2[0-3]):[0-5]\\d$"
       },
       "closes": {
         "type": "string",
@@ -32,7 +32,7 @@
         "examples": [
           "17:00"
         ],
-        "pattern": "^\\d?\\d:\\d\\d$"
+        "pattern": "^([01]?\\d|2[0-3]):[0-5]\\d$"
       },
       "dayOfWeek": {
         "type": "array",


### PR DESCRIPTION
### Changed

- Made the regexp for minute/hour in opening hours more strict (no longer allow things like 25:70).

---

Ticket: https://jira.uitdatabank.be/browse/III-7070 