### PR TITLE
III-7203 Use kebab-case for endpoints

### DIFF
--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -1920,7 +1920,7 @@
         }
       }
     },
-    "/events/{eventId}/departurePlaces": {
+    "/events/{eventId}/departure-places": {
       "parameters": [
         {
           "$ref": "#/components/parameters/eventId"
@@ -1928,7 +1928,7 @@
       ],
       "put": {
         "summary": "departurePlaces - update",
-        "operationId": "event-departurePlaces-put",
+        "operationId": "event-departure-places-put",
         "responses": {
           "204": {
             "description": "No Content. The departure places have been successfully updated."


### PR DESCRIPTION
### Changed

- `entry.json`: Use `kebab-case` for `departure-places`, `birthdate-range` was already ok.

### Related PR

- https://github.com/cultuurnet/udb3-backend/pull/2252

---

Ticket: https://jira.publiq.be/browse/III-7203
