### PR TITLE
Hide BOA page in the nav

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -1,5 +1,7 @@
 # Creating BOA activities (Buitenschoolse Opvang en Activiteiten)
 
+> ⚠️ **Warning:** IN DEVELOPMENT! The BOA endpoints are still in development and subject to change. Do not rely on them in production integrations yet.
+
 The BOA decree aims to create a comprehensive and integrated offering of out-of-school care and leisure activities for school-aged children in Flanders. Local governments act as the central directors, coordinating with partners across education, youth work, sports, and culture.
 To properly capture this specific offering in UiTdatabank, several features and fields have been added to the API. This guide provides an overview of all BOA-specific data models and endpoints.
 

--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -137,12 +137,6 @@
               "title": "Deleting an event",
               "uri": "/docs/entry-api/events/delete.md",
               "slug": "entry-api/events/deleting-an-event"
-            },
-            {
-              "type": "item",
-              "title": "Creating BOA activities",
-              "uri": "/docs/entry-api/events/create-boa.md",
-              "slug": "entry-api/events/create-boa"
             }
           ]
         },


### PR DESCRIPTION
Hiding the central BOA documentation for now, because all endpoints are still in development, and we don't want integrators to be confused.

### Changed

- Remove page from navigation
- You can still find it via the link itself, so that we can share the page internally/provide feedback.
- A large warning will appear on the page itself stating that it is still fully in development, in case someone finds it anyway because they already had the URL.

Unfortunately, I cannot hide it behind a login screen; that only works for new endpoints.
