### PR TITLE
Release notes 2025

### DIFF
--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -1,0 +1,151 @@
+# 2025 Deployments
+
+## December
+
+✨ **New features**
+
+* Integration with Verenigingsloket. UiTdatabank now connects directly to the Verenigingsloket API to look up the connection between an organizer and Verenigingsloket.
+  * `GET /organizers/{organizerId}/verenigingsloket` returns the `vcode` and the link to the organizer's Verenigingsloket page. The response now also includes the connection `status` (cancelled / confirmed), or a `404` when no connection exists.
+  * `DELETE /organizers/{organizerId}/verenigingsloket` removes the connection.
+
+## November
+
+✨ **New features**
+
+* New endpoint `GET /users/{userId}` to retrieve a single user.
+* Automatic UiTPAS labels on places and organizers. Whenever an UiTPAS card system is added or removed in the UiTPAS application for a location or organizer, the corresponding label is now added or removed automatically.
+* Ownership search (`GET /ownerships`) now supports a `sort` parameter.
+
+🛠 **Improvements**
+* "All ages" age ranges (`-`) are now projected consistently as `-` everywhere, instead of mixed representations.
+* Ownership requests on organizers without a creator are now handled gracefully: the helpdesk receives the request mail, and the first approved owner is set as the creator of the organizer.
+* The YouTube trailers cronjob now halts cleanly when the YouTube API daily quota is exhausted.
+
+## October
+
+✨ **New features**
+
+* New endpoint `GET /addresses/streets` that suggests valid streets via the bpost address API, with caching.
+
+🛠 **Improvements**
+
+* The "beheeraanvraag" confirmation mail now links to the manage-ownership page instead of the previous (outdated) link.
+
+## September
+
+✨ **New features**
+
+* Creators of an organizer now have implicit ownership of all events organized by that organizer.
+* Saved searches for approved ownerships are exposed through the saved searches API.
+
+🛠 **Improvements**
+
+* Duplicate place detection now always picks an UiTPAS location as the canonical place when present. An error is thrown when there are multiple UiTPAS locations, or both an UiTPAS and a MuseumPass location in the same cluster.
+
+🐛 **Bugfixes**
+
+* Saved searches no longer return results for deleted or rejected organizers.
+* Looking up the creator of an organizer that has none now returns a clean `404` instead of crashing.
+* `OwnershipSavedSearchRepository` no longer fails on events/places without a `mainLanguage`.
+
+## August
+
+🛠 **Improvements**
+
+* JWT Provider v2 tokens: domain messages now correctly include the `apiKey` when authenticated with a v2 token.
+* Facet mapping files (facilities, themes, types) are now bundled with the application instead of being maintained in 3 separate appconfig copies, removing a source of drift between environments.
+
+## July
+
+✨ **New features**
+
+* `ownerId` is now optional on `POST /ownerships`. When omitted, the currently authenticated user is used as the owner.
+
+🐛 **Bugfixes**
+
+* When creating or updating an event with a place that has been identified as a duplicate, the event is now automatically linked to the canonical place instead of the duplicate one.
+
+## May
+
+✨ **New features**
+
+* New endpoints to replace all manually-added labels in a single request:
+  * `PUT /events/{eventId}/labels/`
+  * `PUT /places/{placeId}/labels/`
+  * `PUT /organizers/{organizerId}/labels/`
+* Cultuurkuur taxonomies refresh:
+  * Unique region labels (no more duplicates).
+  * Province labels are now also applied at the province level.
+  * The unused `reg-*` region label and the `+ deelgemeenten` suffix have been removed.
+  * Educational levels at level 3 have been refined.
+
+🛠 **Improvements**
+
+* Ownership requests now validate that `ownerId` exists in the system, with a clean error for unknown users.
+* The existing CLI command for updating locality now also supports organizers (in addition to places), to support municipal mergers.
+* New admin CLI command `ownership:add` to add ownerships in bulk without sending notification mails.
+
+## April
+
+✨ **New features**
+
+* New backend endpoints serving a static list of municipalities (including their educational levels) and a list of educational levels, to be consumed by Cultuurkuur.
+* New CLI script to update the name of places after municipal mergers, based on a SAPI3 query.
+* `groupPrice` is now supported on tariffs of events and places.
+
+🛠 **Improvements**
+
+* Ownership state changes (approval / rejection / deletion) now record the approver's `userId`, email and date, and these are exposed in the ownership projection.
+* The "beheers aanvraag" / "beheersaanvraag" wording in mails is now consistently "beheeraanvraag".
+
+🐛 **Bugfixes**
+
+* Users can now be re-approved for the same ownership (a duplicate-mail check that incorrectly blocked re-approval has been removed).
+
+## March
+
+✨ **New features**
+
+* Mails are now sent when an ownership is approved or rejected.
+* Ownership mails are sent to the correct recipients: creator + users with roles granting access to the organizer, as well as the original requester.
+
+## February
+
+✨ **New features**
+
+* Mail is now sent to the owners of an organizer when an ownership request is received.
+* Description and images of organizers are now included in their RDF projection.
+
+🛠 **Improvements**
+
+* The `/labels` endpoint now enforces a maximum limit of 30 results and uses sensible defaults when called without `start` / `limit`, to mitigate denial-of-service requests.
+* API key authentication, the API key consumer read repository and the user identity resolver are now cached (Symfony Cache), reducing load on Keycloak.
+* Image `copyrightHolder` is now clipped at 250 characters instead of failing on overly long values.
+* RDF: blank nodes for image objects and other nested resources are replaced by named nodes with a stable hash; the predicate URI for labels changed from `rdfs:label` to `dcat:keyword`; capitalisation of hashes is now consistent. The `blank_nodes_allowed` feature flag has been removed — the new RDF projection is now permanent.
+
+🐛 **Bugfixes**
+
+* Updating a non-existent organizer now returns `403` (consistent with offers and places) instead of `404`.
+* `terms` is now correctly cast to an array during replay, fixing a small set of legacy events that failed to replay.
+* `null` values are no longer cached in the user identity resolver.
+* Fix for the RDF class of virtual locations (now `schema:VirtualLocation` with predicate `platform:virtueleLocatie`).
+
+## January
+
+✨ **New features**
+
+* RDF: blank nodes for many nested resources have been replaced by named nodes with a stable URI hash, behind a feature flag (enabled by default in February). Affected nodes include `Identifier`, `VirtualLocation`, `PeriodOfTime`, `Geometry`, `OpeningHoursSpecification`, `Address`, `Tariff` / `Money`, `ContactPoint`, `VideoObject`, `BookingInfo`, `Spacetime_Volume` and the dummy organizer.
+
+🛠 **Improvements**
+
+* Access to ownership endpoints is now restricted:
+  * `GET /ownerships` requires admin, owner, requester or the appropriate permission.
+  * `GET /ownerships/{id}` requires admin, owner, requester or the appropriate permission.
+* Per-`clientId` default queries are now applied in addition to the existing per-`apiKey` default queries.
+* The `/labels` endpoint always enforces a maximum number of results, even when no `limit` is provided.
+* The `Address` value object has been refactored. Historical events with an empty `Street` can still be loaded from the event store.
+
+🐛 **Bugfixes**
+
+* Prevented a crash in the event-place history projector when handling events with a dummy location (no location id) on copy, location update and major info events.
+* When the calendar type does not match the sub-event count of an event, the system now falls back gracefully instead of crashing.

--- a/projects/release-notes/toc.json
+++ b/projects/release-notes/toc.json
@@ -10,6 +10,12 @@
          "type":"divider",
          "title":"UiTdatabank"
       },
+     {
+             "type":"item",
+             "title":"2025",
+             "uri":"docs/uitdatabank/2025.md",
+             "slug":"udb-2025"
+     },
       {
               "type":"item",
               "title":"2024",


### PR DESCRIPTION
Added Release notes for 2025
Based on merged PRs, left out internal subjects, like package upgrades or internal refactors.

Live preview: https://publiq.stoplight.io/docs/release-notes/branches/release-notes%2F2025/udb-2025
