### PR TITLE
Release notes/2026

### DIFF
--- a/projects/release-notes/docs/uitdatabank/2026.md
+++ b/projects/release-notes/docs/uitdatabank/2026.md
@@ -36,7 +36,7 @@ These BOA-features are currently being tested and are under active development. 
 🛠 **Improvements**
 
 * ISO-8601 datetimes without an explicit timezone are now accepted and interpreted as `Europe/Brussels`.
-* Improved duplicate place detection: the canonical service now handles multiple different labels per cluster and always returns a suggested `id` for the canonical place, including a fallback when no canonical match is found through the search query (e.g. because of a differing `global_address_identifier`).
+* Improved duplicate place detection: when creating a place, and receiving a 400 status code because a duplicate places hit, we  always returns a suggested `id` for the canonical place.
 
 
 

--- a/projects/release-notes/docs/uitdatabank/2026.md
+++ b/projects/release-notes/docs/uitdatabank/2026.md
@@ -1,0 +1,76 @@
+# 2026 Deployments
+
+## May
+
+✨ **New features**
+
+* New endpoint `GET /holidays` returning Belgian public holidays and school holidays. Accepts optional `startDate` and `endDate` query parameters (defaults to today through today + 1 year, with a maximum range of 5 years in the future). Results combine public holidays (type `holidays`) and school holidays (type `schoolHolidays`), are sorted by start date, and are cached for 1 month per unique date-range combination.
+
+🛠 **Improvements**
+
+* `remainingCapacity` is now rejected when sent at the top-level `bookingAvailability` of an Event or Place. It is only valid inside `subEvent.bookingAvailability` — previously it was silently accepted and ignored.
+* New endpoints are now exposed using kebab-case (e.g. `/birthdate-range`, `/departure-places`). The previous camelCase paths remain supported for backwards compatibility.
+
+🐛 **Bugfixes**
+
+* Childcare time validation no longer fails when `startDate` / `endDate` are sent as UTC timestamps. Times are now normalized to `Europe/Brussels` before being compared against `childcare.start` and `childcare.end`.
+
+## April
+
+✨ **New features**
+
+* Introduction of `birthdateRange` on events. Integrators can manage the birth-date range of the target audience with the new endpoints `PUT /events/{id}/birthdate-range` and `DELETE /events/{id}/birthdate-range`.
+* Introduction of `departurePlaces` on events. Integrators can link up to 20 places that an event departs from, using `PUT /events/{id}/departure-places` or as part of the event `POST` / `PUT` body. Departure places are also indexed and filterable in Search API via the `q` parameter and the `departurePlaces[]` URL parameter.
+* Introduction of an `overnight` boolean on subEvents for events of type `Kamp of vakantie` (term `0.57.0.0.0`). The flag is automatically reset when the event type changes to something other than `Kamp of vakantie`.
+* Introduction of `openingHoursAdjustedDays` on events and places. Integrators can declare adjusted opening hours for specific periods (start date, end date, opening hours, optional translated description). Validated for overlap and for falling within the calendar range.
+
+🛠 **Improvements**
+
+* `audienceType` is now projected in RDF output for events.
+* All response URLs for events and places are returned in their plural form (`/events/`, `/places/`). Singular forms remain accepted on input.
+* Search API now accepts query bodies through `POST` in addition to `GET` parameters, allowing larger and more complex queries.
+
+🐛 **Bugfixes**
+
+* Fixed `id` and `location.id` projections to consistently use the plural URL form.
+* Fixed the taxonomy terms cache being triggered on construction, which caused unnecessary API calls on every request.
+
+## March
+
+✨ **New features**
+
+* Introduction of `faq` items on events. Integrators can manage FAQs with the new endpoint `PUT /events/{id}/faq` and include `faq` in the event `POST` / `PUT` body.
+* Introduction of `capacity` and `remainingCapacity` on `subEvent.bookingAvailability`.
+* Introduction of `bookingInfo` on subEvents.
+* Introduction of `childcare` times. For events with a `single` or `multiple` calendar, `childcare` can be set per subEvent. For events with a `periodic` or `permanent` calendar, `childcare` can be set per `openingHours` item. Childcare start must be before the event/opening time and childcare end must be after the event/closing time.
+* Introduction of `openingHoursClosedDays` on events and places, to declare exceptional closed periods on top of the regular calendar.
+
+🛠 **Improvements**
+
+* ISO-8601 datetimes without an explicit timezone are now accepted and interpreted as `Europe/Brussels`.
+* Improved duplicate place detection: the canonical service now handles multiple different labels per cluster and always returns a suggested `id` for the canonical place, including a fallback when no canonical match is found through the search query (e.g. because of a differing `global_address_identifier`).
+
+🐛 **Bugfixes**
+
+* Prevented a crash on events imported from UDB2 when an `updateFaqs` command was handled before the FAQ list was initialised.
+
+## February
+
+✨ **New features**
+
+* New value `childrenOnly` for `audienceType` on events, indicating an event aimed specifically at children. The pre-existing `members` audience type remains in place for events that are only accessible to members.
+
+🛠 **Improvements**
+
+* Taxonomy terms (event types, themes, facilities, place types and place facilities) are now fetched from a centralized Taxonomy API endpoint with caching, instead of from hardcoded configuration files. The taxonomy can now be updated without a deployment.
+* API keys for legacy integrations are now matched to Keycloak client IDs, with logging for unmatched keys, in preparation for the deprecation of API keys in favour of client credentials.
+
+🐛 **Bugfixes**
+
+* Fixed a duplicate-key error that occurred when replaying a role-created event.
+
+## January
+
+✨ **New features**
+
+* Image upload now supports a JSON body with an online URL (`POST /images` with a JSON body containing the image URL), in addition to the existing `multipart/form-data` upload.

--- a/projects/release-notes/docs/uitdatabank/2026.md
+++ b/projects/release-notes/docs/uitdatabank/2026.md
@@ -2,14 +2,10 @@
 
 ## May
 
-✨ **New features**
-
-* New endpoint `GET /holidays` returning Belgian public holidays and school holidays. Accepts optional `startDate` and `endDate` query parameters (defaults to today through today + 1 year, with a maximum range of 5 years in the future). Results combine public holidays (type `holidays`) and school holidays (type `schoolHolidays`), are sorted by start date, and are cached for 1 month per unique date-range combination.
 
 🛠 **Improvements**
 
 * `remainingCapacity` is now rejected when sent at the top-level `bookingAvailability` of an Event or Place. It is only valid inside `subEvent.bookingAvailability` — previously it was silently accepted and ignored.
-* New endpoints are now exposed using kebab-case (e.g. `/birthdate-range`, `/departure-places`). The previous camelCase paths remain supported for backwards compatibility.
 
 🐛 **Bugfixes**
 
@@ -26,14 +22,11 @@
 
 🛠 **Improvements**
 
-* `audienceType` is now projected in RDF output for events.
-* All response URLs for events and places are returned in their plural form (`/events/`, `/places/`). Singular forms remain accepted on input.
 * Search API now accepts query bodies through `POST` in addition to `GET` parameters, allowing larger and more complex queries.
 
 🐛 **Bugfixes**
 
 * Fixed `id` and `location.id` projections to consistently use the plural URL form.
-* Fixed the taxonomy terms cache being triggered on construction, which caused unnecessary API calls on every request.
 
 ## March
 
@@ -50,24 +43,18 @@
 * ISO-8601 datetimes without an explicit timezone are now accepted and interpreted as `Europe/Brussels`.
 * Improved duplicate place detection: the canonical service now handles multiple different labels per cluster and always returns a suggested `id` for the canonical place, including a fallback when no canonical match is found through the search query (e.g. because of a differing `global_address_identifier`).
 
-🐛 **Bugfixes**
 
-* Prevented a crash on events imported from UDB2 when an `updateFaqs` command was handled before the FAQ list was initialised.
 
 ## February
 
 ✨ **New features**
 
-* New value `childrenOnly` for `audienceType` on events, indicating an event aimed specifically at children. The pre-existing `members` audience type remains in place for events that are only accessible to members.
+* New boolean field `childrenOnly` on events, indicating an event aimed specifically at children. 
 
 🛠 **Improvements**
 
-* Taxonomy terms (event types, themes, facilities, place types and place facilities) are now fetched from a centralized Taxonomy API endpoint with caching, instead of from hardcoded configuration files. The taxonomy can now be updated without a deployment.
 * API keys for legacy integrations are now matched to Keycloak client IDs, with logging for unmatched keys, in preparation for the deprecation of API keys in favour of client credentials.
 
-🐛 **Bugfixes**
-
-* Fixed a duplicate-key error that occurred when replaying a role-created event.
 
 ## January
 

--- a/projects/release-notes/docs/uitdatabank/2026.md
+++ b/projects/release-notes/docs/uitdatabank/2026.md
@@ -15,13 +15,9 @@ These BOA-features are currently being tested and are under active development. 
 * Introduction of `childcare` times. For events with a `single` or `multiple` calendar, `childcare` can be set per subEvent. For events with a `periodic` or `permanent` calendar, `childcare` can be set per `openingHours` item. Childcare start must be before the event/opening time and childcare end must be after the event/closing time.
 * Introduction of `openingHoursClosedDays` on events and places, to declare exceptional closed periods on top of the regular calendar.
 * New boolean field `childrenOnly` on events, indicating an event aimed specifically at children.
-
+* Introduction of `birthdateRange` on events. Integrators can manage the birth-date range of the target audience with the new endpoints `PUT /events/{id}/birthdate-range` and `DELETE /events/{id}/birthdate-range`.
 
 ## April
-
-✨ **New features**
-
-* Introduction of `birthdateRange` on events. Integrators can manage the birth-date range of the target audience with the new endpoints `PUT /events/{id}/birthdate-range` and `DELETE /events/{id}/birthdate-range`.
 
 🛠 **Improvements**
 

--- a/projects/release-notes/docs/uitdatabank/2026.md
+++ b/projects/release-notes/docs/uitdatabank/2026.md
@@ -1,24 +1,27 @@
 # 2026 Deployments
 
-## May
+## Upcoming
 
+These BOA-features are currently being tested and are under active development. Would you like to start using them? Please contact <technical-support@publiq.be>.
 
-🛠 **Improvements**
+✨ **New features**
 
-* `remainingCapacity` is now rejected when sent at the top-level `bookingAvailability` of an Event or Place. It is only valid inside `subEvent.bookingAvailability` — previously it was silently accepted and ignored.
+* Introduction of `departurePlaces` on events. Integrators can link up to 20 places that an event departs from, using `PUT /events/{id}/departure-places` or as part of the event `POST` / `PUT` body. Departure places are also indexed and filterable in Search API via the `q` parameter and the `departurePlaces[]` URL parameter.
+* Introduction of an `overnight` boolean on subEvents for events of type `Kamp of vakantie` (term `0.57.0.0.0`). The flag is automatically reset when the event type changes to something other than `Kamp of vakantie`.
+* Introduction of `openingHoursAdjustedDays` on events and places. Integrators can declare adjusted opening hours for specific periods (start date, end date, opening hours, optional translated description). Validated for overlap and for falling within the calendar range.
+* Introduction of `faq` items on events. Integrators can manage FAQs with the new endpoint `PUT /events/{id}/faq` and include `faq` in the event `POST` / `PUT` body.
+* Introduction of `capacity` and `remainingCapacity` on `subEvent.bookingAvailability`.
+* Introduction of `bookingInfo` on subEvents.
+* Introduction of `childcare` times. For events with a `single` or `multiple` calendar, `childcare` can be set per subEvent. For events with a `periodic` or `permanent` calendar, `childcare` can be set per `openingHours` item. Childcare start must be before the event/opening time and childcare end must be after the event/closing time.
+* Introduction of `openingHoursClosedDays` on events and places, to declare exceptional closed periods on top of the regular calendar.
+* New boolean field `childrenOnly` on events, indicating an event aimed specifically at children.
 
-🐛 **Bugfixes**
-
-* Childcare time validation no longer fails when `startDate` / `endDate` are sent as UTC timestamps. Times are now normalized to `Europe/Brussels` before being compared against `childcare.start` and `childcare.end`.
 
 ## April
 
 ✨ **New features**
 
 * Introduction of `birthdateRange` on events. Integrators can manage the birth-date range of the target audience with the new endpoints `PUT /events/{id}/birthdate-range` and `DELETE /events/{id}/birthdate-range`.
-* Introduction of `departurePlaces` on events. Integrators can link up to 20 places that an event departs from, using `PUT /events/{id}/departure-places` or as part of the event `POST` / `PUT` body. Departure places are also indexed and filterable in Search API via the `q` parameter and the `departurePlaces[]` URL parameter.
-* Introduction of an `overnight` boolean on subEvents for events of type `Kamp of vakantie` (term `0.57.0.0.0`). The flag is automatically reset when the event type changes to something other than `Kamp of vakantie`.
-* Introduction of `openingHoursAdjustedDays` on events and places. Integrators can declare adjusted opening hours for specific periods (start date, end date, opening hours, optional translated description). Validated for overlap and for falling within the calendar range.
 
 🛠 **Improvements**
 
@@ -30,14 +33,6 @@
 
 ## March
 
-✨ **New features**
-
-* Introduction of `faq` items on events. Integrators can manage FAQs with the new endpoint `PUT /events/{id}/faq` and include `faq` in the event `POST` / `PUT` body.
-* Introduction of `capacity` and `remainingCapacity` on `subEvent.bookingAvailability`.
-* Introduction of `bookingInfo` on subEvents.
-* Introduction of `childcare` times. For events with a `single` or `multiple` calendar, `childcare` can be set per subEvent. For events with a `periodic` or `permanent` calendar, `childcare` can be set per `openingHours` item. Childcare start must be before the event/opening time and childcare end must be after the event/closing time.
-* Introduction of `openingHoursClosedDays` on events and places, to declare exceptional closed periods on top of the regular calendar.
-
 🛠 **Improvements**
 
 * ISO-8601 datetimes without an explicit timezone are now accepted and interpreted as `Europe/Brussels`.
@@ -46,10 +41,6 @@
 
 
 ## February
-
-✨ **New features**
-
-* New boolean field `childrenOnly` on events, indicating an event aimed specifically at children. 
 
 🛠 **Improvements**
 

--- a/projects/release-notes/toc.json
+++ b/projects/release-notes/toc.json
@@ -12,6 +12,12 @@
       },
      {
              "type":"item",
+             "title":"2026",
+             "uri":"docs/uitdatabank/2026.md",
+             "slug":"udb-2026"
+     },
+     {
+             "type":"item",
              "title":"2025",
              "uri":"docs/uitdatabank/2025.md",
              "slug":"udb-2025"


### PR DESCRIPTION
Added Release notes for 2026
Based on merged PRs, left out internal subjects, like package upgrades or internal refactors.

Live preview: https://publiq.stoplight.io/docs/release-notes/branches/release-notes%2F2026/udb-2026