### PR TITLE
Remove references to internal changes in 2025 release notes

### DIFF
--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -2,7 +2,7 @@
 
 ## December
 
-No public-facing changes.
+No public-facing API changes.
 
 ## November
 
@@ -15,9 +15,7 @@ No public-facing changes.
 
 ## October
 
-🛠 **Improvements**
-
-* The "beheeraanvraag" confirmation mail now links to the manage-ownership page instead of the previous (outdated) link.
+No public-facing API changes.
 
 ## September
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -63,10 +63,6 @@ No public-facing API changes.
 
 ## February
 
-✨ **New features**
-
-* Description and images of organizers are now included in their RDF projection.
-
 🛠 **Improvements**
 
 * The `/labels` endpoint now enforces a maximum limit of 30 results and uses sensible defaults when called without `start` / `limit`, to mitigate denial-of-service requests.

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -27,10 +27,6 @@ No public-facing API changes.
 
 * Duplicate place detection now always picks an UiTPAS location as the canonical place when present. An error is thrown when there are multiple UiTPAS locations, or both an UiTPAS and a MuseumPass location in the same cluster.
 
-🐛 **Bugfixes**
-
-* Looking up the creator of an organizer that has none now returns a clean `404` instead of crashing.
-
 ## August
 
 🛠 **Improvements**

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -65,7 +65,6 @@ No public-facing API changes.
 
 🛠 **Improvements**
 
-* The `/labels` endpoint now enforces a maximum limit of 30 results and uses sensible defaults when called without `start` / `limit`, to mitigate denial-of-service requests.
 * Image `copyrightHolder` is now clipped at 250 characters instead of failing on overly long values.
 
 🐛 **Bugfixes**
@@ -77,7 +76,6 @@ No public-facing API changes.
 🛠 **Improvements**
 
 * Per-`clientId` default queries are now applied in addition to the existing per-`apiKey` default queries.
-* The `/labels` endpoint always enforces a maximum number of results, even when no `limit` is provided.
 
 🐛 **Bugfixes**
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -12,7 +12,6 @@ No public-facing changes.
 
 🛠 **Improvements**
 * "All ages" age ranges (`-`) are now projected consistently as `-` everywhere, instead of mixed representations.
-* Ownership requests on organizers without a creator are now handled gracefully: the helpdesk receives the request mail, and the first approved owner is set as the creator of the organizer.
 * The YouTube trailers cronjob now halts cleanly when the YouTube API daily quota is exhausted.
 
 ## October

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -71,7 +71,6 @@ No public-facing API changes.
 🐛 **Bugfixes**
 
 * Updating a non-existent organizer now returns `403` (consistent with offers and places) instead of `404`.
-* Fix for the RDF class of virtual locations (now `schema:VirtualLocation` with predicate `platform:virtueleLocatie`).
 
 ## January
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -74,10 +74,6 @@ No public-facing API changes.
 
 ## January
 
-✨ **New features**
-
-* RDF: blank nodes for many nested resources have been replaced by named nodes with a stable URI hash, behind a feature flag (enabled by default in February). Affected nodes include `Identifier`, `VirtualLocation`, `PeriodOfTime`, `Geometry`, `OpeningHoursSpecification`, `Address`, `Tariff` / `Money`, `ContactPoint`, `VideoObject`, `BookingInfo`, `Spacetime_Volume` and the dummy organizer.
-
 🛠 **Improvements**
 
 * Access to ownership endpoints is now restricted:

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -53,7 +53,6 @@ No public-facing API changes.
 
 🛠 **Improvements**
 
-* Ownership requests now validate that `ownerId` exists in the system, with a clean error for unknown users.
 * The existing CLI command for updating locality now also supports organizers (in addition to places), to support municipal mergers.
 * New admin CLI command `ownership:add` to add ownerships in bulk without sending notification mails.
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -8,7 +8,6 @@ No public-facing changes.
 
 ✨ **New features**
 
-* New endpoint `GET /users/{userId}` to retrieve a single user.
 * Automatic UiTPAS labels on places and organizers. Whenever an UiTPAS card system is added or removed in the UiTPAS application for a location or organizer, the corresponding label is now added or removed automatically.
 * Ownership search (`GET /ownerships`) now supports a `sort` parameter.
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -22,7 +22,6 @@ No public-facing API changes.
 ✨ **New features**
 
 * Creators of an organizer now have implicit ownership of all events organized by that organizer.
-* Saved searches for approved ownerships are exposed through the saved searches API.
 
 🛠 **Improvements**
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -15,10 +15,6 @@ No public-facing changes.
 
 ## October
 
-✨ **New features**
-
-* New endpoint `GET /addresses/streets` that suggests valid streets via the bpost address API, with caching.
-
 🛠 **Improvements**
 
 * The "beheeraanvraag" confirmation mail now links to the manage-ownership page instead of the previous (outdated) link.

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -2,11 +2,7 @@
 
 ## December
 
-✨ **New features**
-
-* Integration with Verenigingsloket. UiTdatabank now connects directly to the Verenigingsloket API to look up the connection between an organizer and Verenigingsloket.
-  * `GET /organizers/{organizerId}/verenigingsloket` returns the `vcode` and the link to the organizer's Verenigingsloket page. The response now also includes the connection `status` (cancelled / confirmed), or a `404` when no connection exists.
-  * `DELETE /organizers/{organizerId}/verenigingsloket` removes the connection.
+No public-facing changes.
 
 ## November
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -55,7 +55,6 @@ No public-facing API changes.
 
 ✨ **New features**
 
-* New CLI script to update the name of places after municipal mergers, based on a SAPI3 query.
 * `groupPrice` is now supported on tariffs of events and places.
 
 🛠 **Improvements**

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -29,9 +29,7 @@ No public-facing API changes.
 
 🐛 **Bugfixes**
 
-* Saved searches no longer return results for deleted or rejected organizers.
 * Looking up the creator of an organizer that has none now returns a clean `404` instead of crashing.
-* `OwnershipSavedSearchRepository` no longer fails on events/places without a `mainLanguage`.
 
 ## August
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -66,7 +66,6 @@ No public-facing API changes.
 🛠 **Improvements**
 
 * The `/labels` endpoint now enforces a maximum limit of 30 results and uses sensible defaults when called without `start` / `limit`, to mitigate denial-of-service requests.
-* API key authentication, the API key consumer read repository and the user identity resolver are now cached (Symfony Cache), reducing load on Keycloak.
 * Image `copyrightHolder` is now clipped at 250 characters instead of failing on overly long values.
 
 🐛 **Bugfixes**

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -79,5 +79,4 @@ No public-facing API changes.
 
 🐛 **Bugfixes**
 
-* Prevented a crash in the event-place history projector when handling events with a dummy location (no location id) on copy, location update and major info events.
 * When the calendar type does not match the sub-event count of an event, the system now falls back gracefully instead of crashing.

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -31,7 +31,6 @@ No public-facing API changes.
 
 🛠 **Improvements**
 
-* JWT Provider v2 tokens: domain messages now correctly include the `apiKey` when authenticated with a v2 token.
 * Facet mapping files (facilities, themes, types) are now bundled with the application instead of being maintained in 3 separate appconfig copies, removing a source of drift between environments.
 
 ## July

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -51,11 +51,6 @@ No public-facing API changes.
   * The unused `reg-*` region label and the `+ deelgemeenten` suffix have been removed.
   * Educational levels at level 3 have been refined.
 
-🛠 **Improvements**
-
-* The existing CLI command for updating locality now also supports organizers (in addition to places), to support municipal mergers.
-* New admin CLI command `ownership:add` to add ownerships in bulk without sending notification mails.
-
 ## April
 
 ✨ **New features**

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -71,7 +71,6 @@ No public-facing API changes.
 🐛 **Bugfixes**
 
 * Updating a non-existent organizer now returns `403` (consistent with offers and places) instead of `404`.
-* `null` values are no longer cached in the user identity resolver.
 * Fix for the RDF class of virtual locations (now `schema:VirtualLocation` with predicate `platform:virtueleLocatie`).
 
 ## January

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -78,7 +78,6 @@ No public-facing API changes.
 
 * Per-`clientId` default queries are now applied in addition to the existing per-`apiKey` default queries.
 * The `/labels` endpoint always enforces a maximum number of results, even when no `limit` is provided.
-* The `Address` value object has been refactored. Historical events with an empty `Street` can still be loaded from the event store.
 
 🐛 **Bugfixes**
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -68,7 +68,6 @@ No public-facing API changes.
 * The `/labels` endpoint now enforces a maximum limit of 30 results and uses sensible defaults when called without `start` / `limit`, to mitigate denial-of-service requests.
 * API key authentication, the API key consumer read repository and the user identity resolver are now cached (Symfony Cache), reducing load on Keycloak.
 * Image `copyrightHolder` is now clipped at 250 characters instead of failing on overly long values.
-* RDF: blank nodes for image objects and other nested resources are replaced by named nodes with a stable hash; the predicate URI for labels changed from `rdfs:label` to `dcat:keyword`; capitalisation of hashes is now consistent. The `blank_nodes_allowed` feature flag has been removed — the new RDF projection is now permanent.
 
 🐛 **Bugfixes**
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -76,9 +76,6 @@ No public-facing API changes.
 
 🛠 **Improvements**
 
-* Access to ownership endpoints is now restricted:
-  * `GET /ownerships` requires admin, owner, requester or the appropriate permission.
-  * `GET /ownerships/{id}` requires admin, owner, requester or the appropriate permission.
 * Per-`clientId` default queries are now applied in addition to the existing per-`apiKey` default queries.
 * The `/labels` endpoint always enforces a maximum number of results, even when no `limit` is provided.
 * The `Address` value object has been refactored. Historical events with an empty `Street` can still be loaded from the event store.

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -65,7 +65,6 @@ No public-facing API changes.
 
 ✨ **New features**
 
-* Mail is now sent to the owners of an organizer when an ownership request is received.
 * Description and images of organizers are now included in their RDF projection.
 
 🛠 **Improvements**

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -33,10 +33,6 @@ No public-facing API changes.
 
 ## July
 
-✨ **New features**
-
-* `ownerId` is now optional on `POST /ownerships`. When omitted, the currently authenticated user is used as the owner.
-
 🐛 **Bugfixes**
 
 * When creating or updating an event with a place that has been identified as a duplicate, the event is now automatically linked to the canonical place instead of the duplicate one.

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -55,7 +55,6 @@ No public-facing API changes.
 
 ✨ **New features**
 
-* New backend endpoints serving a static list of municipalities (including their educational levels) and a list of educational levels, to be consumed by Cultuurkuur.
 * New CLI script to update the name of places after municipal mergers, based on a SAPI3 query.
 * `groupPrice` is now supported on tariffs of events and places.
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -71,7 +71,6 @@ No public-facing API changes.
 🐛 **Bugfixes**
 
 * Updating a non-existent organizer now returns `403` (consistent with offers and places) instead of `404`.
-* `terms` is now correctly cast to an array during replay, fixing a small set of legacy events that failed to replay.
 * `null` values are no longer cached in the user identity resolver.
 * Fix for the RDF class of virtual locations (now `schema:VirtualLocation` with predicate `platform:virtueleLocatie`).
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -12,7 +12,6 @@ No public-facing changes.
 
 🛠 **Improvements**
 * "All ages" age ranges (`-`) are now projected consistently as `-` everywhere, instead of mixed representations.
-* The YouTube trailers cronjob now halts cleanly when the YouTube API daily quota is exhausted.
 
 ## October
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -29,9 +29,7 @@ No public-facing API changes.
 
 ## August
 
-🛠 **Improvements**
-
-* Facet mapping files (facilities, themes, types) are now bundled with the application instead of being maintained in 3 separate appconfig copies, removing a source of drift between environments.
+No public-facing API changes.
 
 ## July
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -59,10 +59,7 @@ No public-facing API changes.
 
 ## March
 
-✨ **New features**
-
-* Mails are now sent when an ownership is approved or rejected.
-* Ownership mails are sent to the correct recipients: creator + users with roles granting access to the organizer, as well as the original requester.
+No public-facing API changes.
 
 ## February
 

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -57,15 +57,6 @@ No public-facing API changes.
 
 * `groupPrice` is now supported on tariffs of events and places.
 
-🛠 **Improvements**
-
-* Ownership state changes (approval / rejection / deletion) now record the approver's `userId`, email and date, and these are exposed in the ownership projection.
-* The "beheers aanvraag" / "beheersaanvraag" wording in mails is now consistently "beheeraanvraag".
-
-🐛 **Bugfixes**
-
-* Users can now be re-approved for the same ownership (a duplicate-mail check that incorrectly blocked re-approval has been removed).
-
 ## March
 
 ✨ **New features**

--- a/projects/release-notes/docs/uitdatabank/2025.md
+++ b/projects/release-notes/docs/uitdatabank/2025.md
@@ -9,7 +9,6 @@ No public-facing changes.
 ✨ **New features**
 
 * Automatic UiTPAS labels on places and organizers. Whenever an UiTPAS card system is added or removed in the UiTPAS application for a location or organizer, the corresponding label is now added or removed automatically.
-* Ownership search (`GET /ownerships`) now supports a `sort` parameter.
 
 🛠 **Improvements**
 * "All ages" age ranges (`-`) are now projected consistently as `-` everywhere, instead of mixed representations.


### PR DESCRIPTION
### Removed

- Release notes about internal ownerships endpoints
- Release notes about internal saved-searches endpoints
- Release notes about internal refactorings (e.g. Address valueobject)
- Release notes about internal optimizations (e.g. caching, crashing projectors, de-duplicated config, ...)
- Release notes about internal labels endpoint
- Release notes about internal user endpoint
- Release notes about internal address endpoint (Bpost proxy)
- Release notes about internal RDF projection
- Release notes about internal Cultuurkuur changes
- Release notes about CLI commands and cronjobs

---

Not 100% sure about some but I double checked per release note if an endpoint was documented or not, and if yes if it was marked as internal or not. If it was not documented I also consider it internal since it's not easily discoverable by integrators (like endpoints marked as internal)
