### PR TITLE
Remove departure places from Search TOC

### DIFF
--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -396,12 +396,6 @@
             },
             {
               "type": "item",
-              "title": "Filtering by departure places",
-              "uri": "/docs/search-api/filters/departure-places.md",
-              "slug": "search-api/filters/filtering-by-departure-places"
-            },
-            {
-              "type": "item",
               "title": "Filtering by labels",
               "uri": "/docs/search-api/filters/labels.md",
               "slug": "search-api/filters/filtering-by-labels"


### PR DESCRIPTION
### Removed
- Removed departure places from Search TOC as we don't want to expose all new BOA features in plain sight.
