### PR TITLE
III-7233 refactor childrenOnly to a separate boolean

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -15,29 +15,29 @@ For more general information about publiq's role in the BOA decree, visit [publi
 | [`faq`](/docs/uitdatabank/event-faqs) | all | Up to 30 items; dedicated `PUT /events/{eventId}/faqs` endpoint |
 | [`openingHoursClosedDays`](../shared/calendar-info.md#adjusted-closed-days-periodicpermanent) | periodic, permanent | Date ranges with optional localized description |
 | [`openingHoursAdjustedDays`](../shared/calendar-info.md#adjusted-opening-hours-periodicpermanent) | periodic, permanent | Date ranges with custom schedule |
-| [`audience.audienceType: childrenOnly`](#audiencetype) | all | Unlocks `departurePlaces` |
+| [`childrenOnly`](#childrenonly) | all | Boolean flag; unlocks `departurePlaces` when `true` |
 | [`bookingInfo` on subEvents](../shared/booking-and-contact-info.md#bookinginfo) | single, multiple | Per-date booking contacts |
 | [`bookingAvailability` capacity/remainingCapacity](./booking-availability.md) | single, multiple | See also [booking availability guide](./booking-availability.md) |
 | [`childcare`](../shared/calendar-info.md#childcare-times-events-only) | single/multiple (subEvent), periodic (openingHours) | Different placement per calendar type |
-| [`departurePlaces`](#departureplaces) | all (requires `childrenOnly`) | Dedicated `PUT /events/{eventId}/departurePlaces` endpoint |
+| [`departurePlaces`](#departureplaces) | all (requires `childrenOnly: true`) | Dedicated `PUT /events/{eventId}/departurePlaces` endpoint |
 
-## audienceType
+## childrenOnly
 
-To indicate that an event is only for children, you must include an extra property `audienceType` and set the value to `childrenOnly`.
+To indicate that an event is only for children (without parents or guardians), set the optional `childrenOnly` boolean property on the event to `true`. The property defaults to `false` and is not required when creating an event.
 
 ```json
 {
-  "audience": {
-    "audienceType": "childrenOnly"
-  }
+  "childrenOnly": true
 }
 ```
+
+You can also update this flag later using the dedicated [`PUT /events/{eventId}/childrenOnly`](/reference/entry.json/paths/~1events~1{eventId}~1children-only/put) endpoint. If an update request does not include `childrenOnly`, the value is not changed.
 
 ## departurePlaces
 
 This optional property contains a list of URIs referencing schools or other locations from which transport is arranged to bring children to the event. This can be a walk, a bus, or a bicycle taxi that takes children from a school or childcare location to the event's location.
 
-Departure places can only be set on events where `audienceType` is `childrenOnly`. Each URI must reference an existing place in UiTdatabank. A maximum of 20 departure places can be added to an event.
+Departure places can only be set on events where `childrenOnly` is `true`. Each URI must reference an existing place in UiTdatabank. A maximum of 20 departure places can be added to an event.
 
 To find the right place URI, read our guide about [finding and reusing existing places](../places/finding-and-reusing-places.md). If the place does not exist yet, you can [create a new place](../places/create.md).
 
@@ -45,7 +45,7 @@ You can also update departure places later using the dedicated [`PUT /events/{ev
 
 ## Request body example
 
-Example for a BOA event (calendarType `single`) with `childrenOnly` audience, using the term `0.57.0.0.0` ("Kamp of vakantie") which also enables `overnight`:
+Example for a BOA event (calendarType `single`) with `childrenOnly` set to `true`, using the term `0.57.0.0.0` ("Kamp of vakantie") which also enables `overnight`:
 
 ```json
 {
@@ -84,9 +84,7 @@ Example for a BOA event (calendarType `single`) with `childrenOnly` audience, us
       }
     }
   ],
-  "audience": {
-    "audienceType": "childrenOnly"
-  },
+  "childrenOnly": true,
   "faq": [
     {
       "nl": {
@@ -178,9 +176,7 @@ Example for a BOA event (calendarType `periodic`) showing `openingHoursClosedDay
       ]
     }
   ],
-  "audience": {
-    "audienceType": "childrenOnly"
-  },
+  "childrenOnly": true,
   "faq": [
     {
       "nl": {

--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -23,7 +23,7 @@ For more general information about publiq's role in the BOA decree, visit [publi
 
 ## childrenOnly
 
-To indicate that an event is only for children (without parents or guardians), set the optional `childrenOnly` boolean property on the event to `true`. The property defaults to `false` and is not required when creating an event.
+To indicate that an event is only for children (without parents or guardians), set the `childrenOnly` boolean property on the event to `true`. 
 
 ```json
 {

--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -33,6 +33,8 @@ To indicate that an event is only for children (without parents or guardians), s
 
 You can also update this flag later using the dedicated [`PUT /events/{eventId}/childrenOnly`](/reference/entry.json/paths/~1events~1{eventId}~1children-only/put) endpoint. If an update request does not include `childrenOnly`, the value is not changed.
 
+When `childrenOnly` is `false`, it is omitted from the event GET response.
+
 ## departurePlaces
 
 This optional property contains a list of URIs referencing schools or other locations from which transport is arranged to bring children to the event. This can be a walk, a bus, or a bicycle taxi that takes children from a school or childcare location to the event's location.

--- a/projects/uitdatabank/models/common-departurePlaces.json
+++ b/projects/uitdatabank/models/common-departurePlaces.json
@@ -1,7 +1,7 @@
 {
   "type": "array",
   "title": "departurePlaces",
-  "description": "A list of URIs representing departure places for events with audienceType childrenOnly. Each URI must reference an existing place in UiTdatabank.",
+  "description": "A list of URIs representing departure places for events where `childrenOnly` is `true`. Each URI must reference an existing place in UiTdatabank.",
   "uniqueItems": true,
   "maxItems": 20,
   "items": {

--- a/projects/uitdatabank/models/event-audience.json
+++ b/projects/uitdatabank/models/event-audience.json
@@ -19,10 +19,9 @@
       "enum": [
         "everyone",
         "members",
-        "education",
-        "childrenOnly"
+        "education"
       ],
-      "description": "Indicates whether the event or place is accessible to `everyone`, `members` only, `education` only or `childrenOnly` without parents or guardians."
+      "description": "Indicates whether the event or place is accessible to `everyone`, `members` only or `education` only."
     }
   },
   "required": [

--- a/projects/uitdatabank/models/event-childrenOnly-put.json
+++ b/projects/uitdatabank/models/event-childrenOnly-put.json
@@ -1,0 +1,12 @@
+{
+  "title": "event.childrenOnly.put",
+  "type": "object",
+  "properties": {
+    "childrenOnly": {
+      "$ref": "./event-childrenOnly.json"
+    }
+  },
+  "required": [
+    "childrenOnly"
+  ]
+}

--- a/projects/uitdatabank/models/event-childrenOnly.json
+++ b/projects/uitdatabank/models/event-childrenOnly.json
@@ -2,6 +2,6 @@
   "title": "event.childrenOnly",
   "type": "boolean",
   "default": false,
-  "description": "Indicates whether the event is intended for children only, without parents or guardians. Defaults to `false`. Must be `true` to set `departurePlaces`.",
+  "description": "Indicates whether the event is intended for children only, without parents or guardians. Defaults to `false`. Must be `true` to set `departurePlaces`. When not sent in a later update, value remains unchanged.",
   "example": true
 }

--- a/projects/uitdatabank/models/event-childrenOnly.json
+++ b/projects/uitdatabank/models/event-childrenOnly.json
@@ -2,6 +2,6 @@
   "title": "event.childrenOnly",
   "type": "boolean",
   "default": false,
-  "description": "Indicates whether the event is intended for children only, without parents or guardians. Defaults to `false`. Must be `true` to set `departurePlaces`. When not sent in a later update, value remains unchanged.",
+  "description": "Indicates whether the event is intended for children only, without parents or guardians. Defaults to `false`. Must be `true` to set `departurePlaces`. When not sent in a later update, value remains unchanged. When `childrenOnly` is `false`, it is omitted from the event GET response.",
   "example": true
 }

--- a/projects/uitdatabank/models/event-childrenOnly.json
+++ b/projects/uitdatabank/models/event-childrenOnly.json
@@ -1,0 +1,7 @@
+{
+  "title": "event.childrenOnly",
+  "type": "boolean",
+  "default": false,
+  "description": "Indicates whether the event is intended for children only, without parents or guardians. Defaults to `false`. Must be `true` to set `departurePlaces`.",
+  "example": true
+}

--- a/projects/uitdatabank/models/event-departurePlaces.json
+++ b/projects/uitdatabank/models/event-departurePlaces.json
@@ -4,7 +4,7 @@
       "$ref": "./common-departurePlaces.json"
     },
     {
-      "description": "A list of URIs representing departure places for this event. Each URI must reference an existing place in UiTdatabank. Only applicable when the event's audienceType is childrenOnly."
+      "description": "A list of URIs representing departure places for this event. Each URI must reference an existing place in UiTdatabank. Only applicable when the event's `childrenOnly` flag is `true`."
     }
   ],
   "title": "event.departurePlaces"

--- a/projects/uitdatabank/models/event-with-read-example.json
+++ b/projects/uitdatabank/models/event-with-read-example.json
@@ -494,8 +494,9 @@
         }
       ],
       "audience": {
-        "audienceType": "childrenOnly"
+        "audienceType": "everyone"
       },
+      "childrenOnly": true,
       "departurePlaces": [
         "https://io-test.uitdatabank.be/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84",
         "https://io-test.uitdatabank.be/places/a1b2c3d4-e5f6-7890-abcd-ef1234567890"

--- a/projects/uitdatabank/models/event-with-write-example.json
+++ b/projects/uitdatabank/models/event-with-write-example.json
@@ -153,9 +153,7 @@
           "id": "0.52.0.0.0"
         }
       ],
-      "audience": {
-        "audienceType": "childrenOnly"
-      },
+      "childrenOnly": true,
       "departurePlaces": [
         "https://io-test.uitdatabank.be/places/5cf42d51-3a4f-46f0-a8af-1cf672be8c84",
         "https://io-test.uitdatabank.be/places/a1b2c3d4-e5f6-7890-abcd-ef1234567890"

--- a/projects/uitdatabank/models/event.json
+++ b/projects/uitdatabank/models/event.json
@@ -136,6 +136,9 @@
         },
         "departurePlaces": {
           "$ref": "./event-departurePlaces.json"
+        },
+        "childrenOnly": {
+          "$ref": "./event-childrenOnly.json"
         }
       },
       "required": [

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -2049,7 +2049,7 @@
         "tags": [
           "Events"
         ],
-        "description": "Replaces the list of departure places on the event.\n\nDeparture places are schools or other locations from which transport is arranged to bring children to the event (e.g. a walk, a bus, or a bicycle taxi).\n\nPassing an empty array `[]` removes all departure places from the event.\n\n**Validation rules:**\n\n* The event's `audienceType` must be `childrenOnly`. Returns a `400` error if the audience type does not match.\n* Each URI must reference an existing place in UiTdatabank. Returns a `400` error listing the non-existent places.",
+        "description": "Replaces the list of departure places on the event.\n\nDeparture places are schools or other locations from which transport is arranged to bring children to the event (e.g. a walk, a bus, or a bicycle taxi).\n\nPassing an empty array `[]` removes all departure places from the event.\n\n**Validation rules:**\n\n* The event's `childrenOnly` flag must be `true`. Returns a `400` error if `childrenOnly` is not set to `true`.\n* Each URI must reference an existing place in UiTdatabank. Returns a `400` error listing the non-existent places.",
         "security": [
           {
             "USER_ACCESS_TOKEN": []

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -969,7 +969,7 @@
         "tags": [
           "Events"
         ],
-        "description": "Updates the `childrenOnly` flag on the event.\n\nSet to `true` to indicate that the event is intended for children only, without parents or guardians. Defaults to `false`.\n\nThe `childrenOnly` flag must be `true` before any `departurePlaces` can be set on the event.",
+        "description": "Updates the `childrenOnly` flag on the event.\n\nSet to `true` to indicate that the event is intended for children only, without parents or guardians. Defaults to `false`.\n\nThe `childrenOnly` flag must be `true` before any `departurePlaces` can be set on the event.\n\nWhen `childrenOnly` is `false`, it is omitted from the event GET response.\n",
         "security": [
           {
             "USER_ACCESS_TOKEN": []

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -918,6 +918,90 @@
         }
       }
     },
+    "/events/{eventId}/children-only": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/eventId"
+        }
+      ],
+      "put": {
+        "summary": "childrenOnly - update",
+        "operationId": "event-childrenOnly-put",
+        "responses": {
+          "204": {
+            "description": "No Content. The event's childrenOnly flag was successfully updated."
+          },
+          "400": {
+            "description": "Bad Request. Possible error types:\n\n* https://api.publiq.be/probs/body/missing\n* https://api.publiq.be/probs/body/invalid-syntax\n* https://api.publiq.be/probs/body/invalid-data",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "type": "https://api.publiq.be/probs/body/invalid-data",
+                      "title": "Invalid body data",
+                      "status": 400,
+                      "schemaErrors": [
+                        {
+                          "jsonPointer": "/childrenOnly",
+                          "error": "The data (string) should match the type: boolean"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "tags": [
+          "Events"
+        ],
+        "description": "Updates the `childrenOnly` flag on the event.\n\nSet to `true` to indicate that the event is intended for children only, without parents or guardians. Defaults to `false`.\n\nThe `childrenOnly` flag must be `true` before any `departurePlaces` can be set on the event.",
+        "security": [
+          {
+            "USER_ACCESS_TOKEN": []
+          },
+          {
+            "CLIENT_ACCESS_TOKEN": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "../models/event-childrenOnly-put.json"
+              },
+              "examples": {
+                "Enable": {
+                  "value": {
+                    "childrenOnly": true
+                  }
+                },
+                "Disable": {
+                  "value": {
+                    "childrenOnly": false
+                  }
+                }
+              }
+            }
+          },
+          "description": "New value for the `childrenOnly` flag on the event."
+        }
+      }
+    },
     "/events/{eventId}/available-from": {
       "parameters": [
         {


### PR DESCRIPTION

## Summary

Refactors `childrenOnly` away from the `audienceType` enum into its own dedicated boolean property on the event.

- Removes `childrenOnly` from the `audienceType` enum
- Adds a new optional `childrenOnly` boolean on event (default `false`, not required)
- Adds a new dedicated endpoint `PUT /events/{eventId}/children-only` to update the flag
- Updates `departurePlaces` validation so it now requires `childrenOnly: true` instead of `audienceType: childrenOnly`
- Updates the create-boa guide and event read/write examples accordingly

Omitting `childrenOnly` from the PUT endpoint leaves the existing value unchanged.

## Preview
https://publiq.stoplight.io/docs/uitdatabank/branches/III-7233%2Frefactor-childrenonly-to-a-seperate-boolean/entry-api/reference/operations/update-a-event-children-only