### PR TITLE
Update URI regex

### DIFF
--- a/projects/uitdatabank/models/common-string-uri-readOnly.json
+++ b/projects/uitdatabank/models/common-string-uri-readOnly.json
@@ -1,11 +1,6 @@
 {
-  "title": "uri.readOnly",
-  "description": "A URI with the HTTP or HTTPS protocol. (Read-only)",
-  "type": "string",
-  "format": "uri",
-  "pattern": "^http[s]?:\\/\\/",
-  "readOnly": true,
-  "examples": [
-    "https://www.example.com"
+  "allOf": [
+    { "$ref": "./common-string-uri.json" },
+    { "readOnly": true }
   ]
 }

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -9550,9 +9550,7 @@
           },
           {
             "schema": {
-              "type": "string",
-              "pattern": "^http[s]?:\\/\\/",
-              "format": "uri"
+              "$ref": "../models/common-string-uri.json"
             },
             "in": "query",
             "name": "url",


### PR DESCRIPTION
Update the readonly version of common uri to extend common uri so they share the same regex (which was made a little bit stricter).
The old version did have "(readonly)" in the title, I dropped this because this seemed such a low value addition, but I can add it back when requested
