### PR TITLE
Restrict bookingAvailability `Unavailable` for permanent/periodic calendars

### DIFF
--- a/projects/uitdatabank/models/event-calendar-put.json
+++ b/projects/uitdatabank/models/event-calendar-put.json
@@ -4,6 +4,27 @@
   "description": "Request body to update the calendar information of an event.",
   "allOf": [
     {
+      "if": {
+        "required": ["calendarType"],
+        "properties": {
+          "calendarType": {
+            "enum": ["permanent", "periodic"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "bookingAvailability": {
+            "properties": {
+              "type": {
+                "not": { "const": "Unavailable" }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "properties": {
         "calendarType": {
           "$ref": "./event-calendarType.json"

--- a/projects/uitdatabank/models/place-calendar-put.json
+++ b/projects/uitdatabank/models/place-calendar-put.json
@@ -34,6 +34,27 @@
   "allOf": [
     {
       "if": {
+        "required": ["calendarType"],
+        "properties": {
+          "calendarType": {
+            "enum": ["permanent", "periodic"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "bookingAvailability": {
+            "properties": {
+              "type": {
+                "not": { "const": "Unavailable" }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
         "required": [
           "calendarType"
         ],


### PR DESCRIPTION
## changes

- Based on the feedback of Luc on PR https://github.com/cultuurnet/udb3-backend/pull/2265 I decided to enforce on the json schema the rule that when when `calendarType` is `permanent` or `periodic`, `bookingAvailability.type` cannot be `Unavailable`.
- `Unavailable` remains valid for `single` and `multiple` calendar types, where individual subEvents exist.

## related
https://github.com/cultuurnet/udb3-backend/pull/226