### PR TITLE
Improve boa docs

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -10,28 +10,17 @@ For more general information about Publiq's role in the BOA decree, visit [publi
 ## Best Practices: Optimizing your reach
 To ensure parents and children easily find the right activities, data quality is crucial. When publishing BOA-related events, we highly recommend sending the following information:
 
-| Type | Endpoint                                                                          | Description | BOA specific |
-|---|-----------------------------------------------------------------------------------|---|---|
-| Target audience | `PUT /events/{eventId}/childrenOnly`                                              | Always explicitly indicate if an activity is meant for "children only" (without parents). This helps our publication channels distinguish BOA activities from general family events. | ✅ |
-| Age range | `PUT /events/{eventId}/typicalAgeRange` or `PUT /events/{eventId}/birthdateRange` | Always communicate the age group your activity is intended for. You can pass a generic age range (`typicalAgeRange`), or the specific birth date range (`birthdateRange`). | ✅ |
-| Pricing | `PUT /events/{eventId}/priceInfo`                                                 | Be transparent about pricing: always send prices per logical "bookable unit" (e.g., per hour, per day, or per week) so the cost is clear to parents. | ❌ |
-| Capacity per timeslot | `PUT /events/{eventId}/calendar` or `PATCH /events/{eventId}/subEvents`           | For holiday playground programmes, childcare, camps, and courses, always include the maximum and remaining capacity per subEvent. Essential for parents and crucial for local BOA-coordinators monitoring local capacity. | ✅ |
-| FAQ | `PUT /events/{eventId}/faq`                                                       | Use the FAQ fields to structure practical information. The ideal place to answer questions about accessibility, required care needs, meals, and what children need to bring. | ✅ |
-| Full schedule | `PUT /events/{eventId}/calendar`                                                  | Parents plan full days. Explicitly pass before- and after-school care hours (`childcare`), adjusted opening hours, and specific holiday closures (`openingHoursAdjustedDays`). | ✅ |
-| Overnight stays | `PATCH /events/{eventId}/subEvents`                                               | For camps, clearly specify if the activity includes an overnight stay (`overnight`). | ✅ |
-| Departure places | `PUT /events/{eventId}/departurePlaces`                                           | If guided transport is provided from a school or another care location to the activity, link these locations. | ✅ |
-
-| Field | Calendar type | Notes |
-|---|---|---|
-| [`overnight`](../shared/calendar-info.md#overnight-events-only-singlemultiple) | single, multiple | Only for term `0.57.0.0.0`; hidden in response when `false` |
-| [`faq`](/docs/uitdatabank/event-faqs) | all | Up to 30 items; dedicated `PUT /events/{eventId}/faqs` endpoint |
-| [`openingHoursClosedDays`](../shared/calendar-info.md#adjusted-closed-days-periodicpermanent) | periodic, permanent | Date ranges with optional localized description |
-| [`openingHoursAdjustedDays`](../shared/calendar-info.md#adjusted-opening-hours-periodicpermanent) | periodic, permanent | Date ranges with custom schedule |
-| [`childrenOnly`](#childrenonly) | all | Boolean flag; unlocks `departurePlaces` when `true` |
-| [`bookingInfo` on subEvents](../shared/booking-and-contact-info.md#bookinginfo) | single, multiple | Per-date booking contacts |
-| [`bookingAvailability` capacity/remainingCapacity](./booking-availability.md) | single, multiple | See also [booking availability guide](./booking-availability.md) |
-| [`childcare`](../shared/calendar-info.md#childcare-times-events-only) | single/multiple (subEvent), periodic (openingHours) | Different placement per calendar type |
-| [`departurePlaces`](#departureplaces) | all (requires `childrenOnly: true`) | Dedicated `PUT /events/{eventId}/departurePlaces` endpoint |
+| Type | Endpoint | Description | Calendar type | BOA specific |
+|---|---|---|---|---|
+| Target audience | `PUT /events/{eventId}/childrenOnly` | Always explicitly indicate if an activity is meant for [children only](#childrenonly) (without parents). This helps our publication channels distinguish BOA activities from general family events. | all | ✅ |
+| Age range | `PUT /events/{eventId}/typicalAgeRange` or `PUT /events/{eventId}/birthdateRange` | Always communicate the age group your activity is intended for. You can pass a generic age range (`typicalAgeRange`), or the specific birth date range (`birthdateRange`). | all | ✅ |
+| Pricing | `PUT /events/{eventId}/priceInfo` | Be transparent about pricing: always send prices per logical "bookable unit" (e.g., per hour, per day, or per week) so the cost is clear to parents. | all | ❌ |
+| Capacity per timeslot | `PUT /events/{eventId}/calendar` or `PATCH /events/{eventId}/subEvents` | For holiday playground programmes, childcare, camps, and courses, always include the maximum and remaining [capacity per subEvent](./booking-availability.md). Essential for parents and crucial for local BOA-coordinators monitoring local capacity. | single, multiple | ✅ |
+| FAQ | `PUT /events/{eventId}/faq` | Use the [FAQ fields](/docs/uitdatabank/event-faqs) to structure practical information. The ideal place to answer questions about accessibility, required care needs, meals, and what children need to bring. | all | ✅ |
+| Full schedule | `PUT /events/{eventId}/calendar` | Parents plan full days. Explicitly pass before- and after-school care hours ([`childcare`](../shared/calendar-info.md#childcare-times-events-only)), [adjusted opening hours](../shared/calendar-info.md#adjusted-opening-hours-periodicpermanent), and [specific holiday closures](../shared/calendar-info.md#adjusted-closed-days-periodicpermanent). | single, multiple, periodic, permanent | ✅ |
+| Overnight stays | `PATCH /events/{eventId}/subEvents` | For camps, clearly specify if the activity includes an [overnight stay](../shared/calendar-info.md#overnight-events-only-singlemultiple) (`overnight`). | single, multiple | ✅ |
+| Departure places | `PUT /events/{eventId}/departurePlaces` | If guided transport is provided from a school or another care location to the activity, [link these locations](#departureplaces). | all (requires `childrenOnly: true`) | ✅ |
+| Booking info | `PATCH /events/{eventId}/subEvents` | Provide [per-date booking contacts](../shared/booking-and-contact-info.md#bookinginfo) on subEvents so parents know where to register for each occurrence. | single, multiple | ❌ |
 
 ## childrenOnly
 

--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -19,18 +19,8 @@ To ensure parents and children easily find the right activities, data quality is
 | FAQ | `PUT /events/{eventId}/faq` | Use the [FAQ fields](/docs/uitdatabank/event-faqs) to structure practical information. The ideal place to answer questions about accessibility, required care needs, meals, and what children need to bring. | all | ✅ |
 | Full schedule | `PUT /events/{eventId}/calendar` | Parents plan full days. Explicitly pass before- and after-school care hours ([`childcare`](../shared/calendar-info.md#childcare-times-events-only)), [adjusted opening hours](../shared/calendar-info.md#adjusted-opening-hours-periodicpermanent), and [specific holiday closures](../shared/calendar-info.md#adjusted-closed-days-periodicpermanent). | single, multiple, periodic, permanent | ✅ |
 | Overnight stays | `PATCH /events/{eventId}/subEvents` | For camps, clearly specify if the activity includes an [overnight stay](../shared/calendar-info.md#overnight-events-only-singlemultiple) (`overnight`). | single, multiple | ✅ |
-| Departure places | `PUT /events/{eventId}/departurePlaces` | If guided transport is provided from a school or another care location to the activity, [link these locations](#departureplaces). | all (requires `childrenOnly: true`) | ✅ |
+| Departure places | `PUT /events/{eventId}/departurePlaces` | If guided transport is provided from a school or another care location to the activity, [link these locations](/docs/uitdatabank/entry-api/reference/operations/update-a-event-departure-places). | all (requires `childrenOnly: true`) | ✅ |
 | Booking info | `PATCH /events/{eventId}/subEvents` | Provide [per-date booking contacts](../shared/booking-and-contact-info.md#bookinginfo) on subEvents so parents know where to register for each occurrence. | single, multiple | ❌ |
-
-## departurePlaces
-
-This optional property contains a list of URIs referencing schools or other locations from which transport is arranged to bring children to the event. This can be a walk, a bus, or a bicycle taxi that takes children from a school or childcare location to the event's location.
-
-Departure places can only be set on events where `childrenOnly` is `true`. Each URI must reference an existing place in UiTdatabank. A maximum of 20 departure places can be added to an event.
-
-To find the right place URI, read our guide about [finding and reusing existing places](../places/finding-and-reusing-places.md). If the place does not exist yet, you can [create a new place](../places/create.md).
-
-You can also update departure places later using the dedicated [`PUT /events/{eventId}/departurePlaces`](/reference/entry.json/paths/~1events~1{eventId}~1departurePlaces/put) endpoint. Passing an empty array `[]` removes all departure places.
 
 ## Request body example
 

--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -3,11 +3,23 @@
 > ⚠️ **Warning:** IN DEVELOPMENT! The BOA endpoints are still in development and subject to change. Do not rely on them in production integrations yet.
 
 The BOA decree aims to create a comprehensive and integrated offering of out-of-school care and leisure activities for school-aged children in Flanders. Local governments act as the central directors, coordinating with partners across education, youth work, sports, and culture.
-To properly capture this specific offering in UiTdatabank, several features and fields have been added to the API. This guide provides an overview of all BOA-specific data models and endpoints.
+To properly capture this specific offering in UiTdatabank, several new features and fields have been added to the Entry API. This guide provides an overview of the best practices and the technical endpoints required to submit BOA data correctly.
 
-For more general information about publiq's role in the BOA decree, visit [publiq.be/boa](https://publiq.be/boa).
+For more general information about Publiq's role in the BOA decree, visit [publiq.be/boa](https://publiq.be/boa).
 
-> This guide covers all BOA-specific fields, how they apply per calendar type, and what endpoints to use.
+## Best Practices: Optimizing your reach
+To ensure parents and children easily find the right activities, data quality is crucial. When publishing BOA-related events, we highly recommend sending the following information:
+
+| Type | Endpoint                                                                          | Description | BOA specific |
+|---|-----------------------------------------------------------------------------------|---|---|
+| Target audience | `PUT /events/{eventId}/childrenOnly`                                              | Always explicitly indicate if an activity is meant for "children only" (without parents). This helps our publication channels distinguish BOA activities from general family events. | ✅ |
+| Age range | `PUT /events/{eventId}/typicalAgeRange` or `PUT /events/{eventId}/birthdateRange` | Always communicate the age group your activity is intended for. You can pass a generic age range (`typicalAgeRange`), or the specific birth date range (`birthdateRange`). | ✅ |
+| Pricing | `PUT /events/{eventId}/priceInfo`                                                 | Be transparent about pricing: always send prices per logical "bookable unit" (e.g., per hour, per day, or per week) so the cost is clear to parents. | ❌ |
+| Capacity per timeslot | `PUT /events/{eventId}/calendar` or `PATCH /events/{eventId}/subEvents`           | For holiday playground programmes, childcare, camps, and courses, always include the maximum and remaining capacity per subEvent. Essential for parents and crucial for local BOA-coordinators monitoring local capacity. | ✅ |
+| FAQ | `PUT /events/{eventId}/faq`                                                       | Use the FAQ fields to structure practical information. The ideal place to answer questions about accessibility, required care needs, meals, and what children need to bring. | ✅ |
+| Full schedule | `PUT /events/{eventId}/calendar`                                                  | Parents plan full days. Explicitly pass before- and after-school care hours (`childcare`), adjusted opening hours, and specific holiday closures (`openingHoursAdjustedDays`). | ✅ |
+| Overnight stays | `PATCH /events/{eventId}/subEvents`                                               | For camps, clearly specify if the activity includes an overnight stay (`overnight`). | ✅ |
+| Departure places | `PUT /events/{eventId}/departurePlaces`                                           | If guided transport is provided from a school or another care location to the activity, link these locations. | ✅ |
 
 | Field | Calendar type | Notes |
 |---|---|---|

--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -12,7 +12,7 @@ To ensure parents and children easily find the right activities, data quality is
 
 | Type | Endpoint | Description | Calendar type | BOA specific |
 |---|---|---|---|---|
-| Target audience | `PUT /events/{eventId}/childrenOnly` | Always explicitly indicate if an activity is meant for [children only](#childrenonly) (without parents). This helps our publication channels distinguish BOA activities from general family events. | all | ✅ |
+| Target audience | `PUT /events/{eventId}/childrenOnly` | Always explicitly indicate if an activity is meant for [children only](/docs/uitdatabank/entry-api/reference/operations/update-a-event-children-only) (without parents). This helps our publication channels distinguish BOA activities from general family events. | all | ✅ |
 | Age range | `PUT /events/{eventId}/typicalAgeRange` or `PUT /events/{eventId}/birthdateRange` | Always communicate the age group your activity is intended for. You can pass a generic age range (`typicalAgeRange`), or the specific birth date range (`birthdateRange`). | all | ✅ |
 | Pricing | `PUT /events/{eventId}/priceInfo` | Be transparent about pricing: always send prices per logical "bookable unit" (e.g., per hour, per day, or per week) so the cost is clear to parents. | all | ❌ |
 | Capacity per timeslot | `PUT /events/{eventId}/calendar` or `PATCH /events/{eventId}/subEvents` | For holiday playground programmes, childcare, camps, and courses, always include the maximum and remaining [capacity per subEvent](./booking-availability.md). Essential for parents and crucial for local BOA-coordinators monitoring local capacity. | single, multiple | ✅ |
@@ -21,20 +21,6 @@ To ensure parents and children easily find the right activities, data quality is
 | Overnight stays | `PATCH /events/{eventId}/subEvents` | For camps, clearly specify if the activity includes an [overnight stay](../shared/calendar-info.md#overnight-events-only-singlemultiple) (`overnight`). | single, multiple | ✅ |
 | Departure places | `PUT /events/{eventId}/departurePlaces` | If guided transport is provided from a school or another care location to the activity, [link these locations](#departureplaces). | all (requires `childrenOnly: true`) | ✅ |
 | Booking info | `PATCH /events/{eventId}/subEvents` | Provide [per-date booking contacts](../shared/booking-and-contact-info.md#bookinginfo) on subEvents so parents know where to register for each occurrence. | single, multiple | ❌ |
-
-## childrenOnly
-
-To indicate that an event is only for children (without parents or guardians), set the `childrenOnly` boolean property on the event to `true`. 
-
-```json
-{
-  "childrenOnly": true
-}
-```
-
-You can also update this flag later using the dedicated [`PUT /events/{eventId}/childrenOnly`](/reference/entry.json/paths/~1events~1{eventId}~1children-only/put) endpoint. If an update request does not include `childrenOnly`, the value is not changed.
-
-When `childrenOnly` is `false`, it is omitted from the event GET response.
 
 ## departurePlaces
 

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -969,7 +969,7 @@
         "tags": [
           "Events"
         ],
-        "description": "Updates the `childrenOnly` flag on the event.\n\nSet to `true` to indicate that the event is intended for children only, without parents or guardians. Defaults to `false`.\n\nThe `childrenOnly` flag must be `true` before any `departurePlaces` can be set on the event.\n\nWhen `childrenOnly` is `false`, it is omitted from the event GET response.\n",
+        "description": "Updates the `childrenOnly` flag on the event.\n\nSet `childrenOnly` to `true` to indicate that the event is intended for children only, without parents or guardians. Defaults to `false`. When `childrenOnly` is `false`, it is omitted from the event GET response.\n\nThe `childrenOnly` flag must be `true` before any `departurePlaces` can be set on the event.\n",
         "security": [
           {
             "USER_ACCESS_TOKEN": []

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -2049,7 +2049,7 @@
         "tags": [
           "Events"
         ],
-        "description": "Replaces the list of departure places on the event.\n\nDeparture places are schools or other locations from which transport is arranged to bring children to the event (e.g. a walk, a bus, or a bicycle taxi).\n\nPassing an empty array `[]` removes all departure places from the event.\n\n**Validation rules:**\n\n* The event's `childrenOnly` flag must be `true`. Returns a `400` error if `childrenOnly` is not set to `true`.\n* Each URI must reference an existing place in UiTdatabank. Returns a `400` error listing the non-existent places.",
+        "description": "Replaces the list of departure places on the event.\n\nDeparture places are schools or other locations from which transport is arranged to bring children to the event. This can be a walk, a bus, or a bicycle taxi that takes children from a school or childcare location to the event's location.\n\nTo find the right place URI, read our guide about [finding and reusing existing places](/docs/entry-api/places/finding-and-reusing-places.md). If the place does not exist yet, you can [create a new place](/docs/entry-api/places/create.md).\n\nPassing an empty array `[]` removes all departure places from the event.\n\n**Validation rules:**\n\n* The event's `childrenOnly` flag must be `true`. Returns a `400` error if `childrenOnly` is not set to `true`.\n* Each URI must reference an existing place in UiTdatabank. Returns a `400` error listing the non-existent places.\n* A maximum of 20 departure places can be set on an event.",
         "security": [
           {
             "USER_ACCESS_TOKEN": []


### PR DESCRIPTION
### Changed

  Restructures the BOA event guide (create-boa.md) around a single best-practices table, containing more guidance which fields are interesting for BOA offers, and moves field-level descriptions into the their specifiic endpoint page.
