### PR TITLE
III-7255 allow capacity on event bookingAvailability for all calendar types

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/booking-availability.md
+++ b/projects/uitdatabank/docs/entry-api/events/booking-availability.md
@@ -184,4 +184,4 @@ For `periodic` events, you may additionally include `remainingCapacity`:
 }
 ```
 
-For `permanent` events, `remainingCapacity` is silently ignored.
+For `permanent` events, sending `remainingCapacity` returns HTTP 400 with error type `https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported`.

--- a/projects/uitdatabank/docs/entry-api/events/booking-availability.md
+++ b/projects/uitdatabank/docs/entry-api/events/booking-availability.md
@@ -184,4 +184,4 @@ For `periodic` events, you may additionally include `remainingCapacity`:
 }
 ```
 
-For `permanent` events, sending `remainingCapacity` returns HTTP 400 with error type `https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported`.
+For `permanent` events, sending `remainingCapacity` returns HTTP 400 with error type `https://api.publiq.be/probs/uitdatabank/remaining-capacity-not-supported`.

--- a/projects/uitdatabank/docs/entry-api/events/booking-availability.md
+++ b/projects/uitdatabank/docs/entry-api/events/booking-availability.md
@@ -163,6 +163,25 @@ Alternatively, you can set the top-level `bookingAvailability` by using the sepa
 
 Events with calendarType `periodic` and `permanent` span a larger period and have a schedule based on recurring `openingHours`.
 
-Because they do not have a `subEvent` property with specific dates, it is impossible to share their booking availability for certain dates at this moment.
+Because they do not have a `subEvent` property with specific dates, it is impossible to share their booking availability for certain dates.
 
-It is also not possible to change their top-level booking availability, because it is unlikely that such a long-running event is ever completely booked (especially in the case of permanent events).
+Their top-level `bookingAvailability.type` is always coerced to `Available`, since it is unlikely that such a long-running event is ever completely booked (especially in the case of permanent events). You can however set `capacity` to indicate the total number of seats or tickets via the [`PUT /events/{eventId}/booking-availability`](/reference/entry.json/paths/~1events~1{eventId}~1booking-availability/put) endpoint:
+
+```json
+{
+  "type": "Available",
+  "capacity": 200
+}
+```
+
+For `periodic` events, you may additionally include `remainingCapacity`:
+
+```json
+{
+  "type": "Available",
+  "capacity": 200,
+  "remainingCapacity": 80
+}
+```
+
+For `permanent` events, `remainingCapacity` is silently ignored.

--- a/projects/uitdatabank/models/event-bookingAvailability.json
+++ b/projects/uitdatabank/models/event-bookingAvailability.json
@@ -1,13 +1,16 @@
 {
   "title": "event.bookingAvailability",
   "type": "object",
-  "description": "Indicates whether the event still has tickets or reservations available. Currently contains a `type` that can be `Available` or `Unavailable`, and can optionally include capacity information.",
+  "description": "Indicates whether the event still has tickets or reservations available. Currently contains a `type` that can be `Available` or `Unavailable`, and can optionally include `capacity` and `remainingCapacity`. Note: `remainingCapacity` is accepted for all calendar types but is only honored for events with calendarType `periodic`; for other calendar types it is ignored by the backend.",
   "properties": {
     "type": {
       "$ref": "./common-bookingAvailability-type.json"
     },
     "capacity": {
       "$ref": "./common-bookingAvailability-capacity.json"
+    },
+    "remainingCapacity": {
+      "$ref": "./common-bookingAvailability-remainingCapacity.json"
     }
   },
   "required": [

--- a/projects/uitdatabank/models/event-bookingAvailability.json
+++ b/projects/uitdatabank/models/event-bookingAvailability.json
@@ -1,7 +1,7 @@
 {
   "title": "event.bookingAvailability",
   "type": "object",
-  "description": "Indicates whether the event still has tickets or reservations available. Currently contains a `type` that can be `Available` or `Unavailable`, and can optionally include `capacity` and `remainingCapacity`. Note: `remainingCapacity` is accepted for all calendar types but is only honored for events with calendarType `periodic`; for other calendar types it is ignored by the backend.",
+  "description": "Indicates whether the event still has tickets or reservations available. Currently contains a `type` that can be `Available` or `Unavailable`, and can optionally include `capacity` and `remainingCapacity`. Note: `remainingCapacity` is only honored for events with calendarType `periodic`; sending it for other calendar types is rejected by the backend with HTTP 400.",
   "properties": {
     "type": {
       "$ref": "./common-bookingAvailability-type.json"

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -1219,7 +1219,7 @@
             "$ref": "#/components/responses/NotFound"
           }
         },
-        "description": "Updates the general bookingAvailability info on the top level of the event with the given `eventId`.\n\nThe type of any subEvents that the event has will also be updated to match the general type in bookingAvailability, unless these subEvents have [remainingCapacity](../docs/entry-api/events/booking-availability.md#the-bookingavailability-property) set.\n\n<!-- theme: warning -->\n\n> Note that you cannot update the bookingAvailability of an event with [calendar type](/models/event-calendarType.json) `periodic` or `permanent`. For now, they can only have \"Available\" as bookingAvailability.",
+        "description": "Updates the general bookingAvailability info on the top level of the event with the given `eventId`.\n\nThe accepted properties and their behavior depend on the event's [calendarType](/models/event-calendarType.json):\n\n* `single` / `multiple`: updates the top-level `type` and `capacity`. The `type` of every subEvent is also updated to match, unless that subEvent already has [remainingCapacity](../docs/entry-api/events/booking-availability.md#the-bookingavailability-property) set. Top-level `remainingCapacity` is not meaningful and is rejected.\n* `periodic`: updates `capacity` and `remainingCapacity`. `type` is always coerced to `Available`.\n* `permanent`: updates `capacity`. `type` is always coerced to `Available`, and `remainingCapacity` is silently dropped.",
         "requestBody": {
           "content": {
             "application/json": {

--- a/projects/uitdatabank/reference/entry.json
+++ b/projects/uitdatabank/reference/entry.json
@@ -1202,7 +1202,7 @@
                       "type": "https://api.publiq.be/probs/uitdatabank/calendar-type-not-supported",
                       "title": "Calendar type not supported",
                       "status": 400,
-                      "detail": "Not allowed to update booking availability on calendar type: \"permanent\". Only single and multiple calendar types can be updated."
+                      "detail": "Not allowed to set remainingCapacity on calendar type: \"permanent\"."
                     }
                   }
                 }
@@ -1219,7 +1219,7 @@
             "$ref": "#/components/responses/NotFound"
           }
         },
-        "description": "Updates the general bookingAvailability info on the top level of the event with the given `eventId`.\n\nThe accepted properties and their behavior depend on the event's [calendarType](/models/event-calendarType.json):\n\n* `single` / `multiple`: updates the top-level `type` and `capacity`. The `type` of every subEvent is also updated to match, unless that subEvent already has [remainingCapacity](../docs/entry-api/events/booking-availability.md#the-bookingavailability-property) set. Top-level `remainingCapacity` is not meaningful and is rejected.\n* `periodic`: updates `capacity` and `remainingCapacity`. `type` is always coerced to `Available`.\n* `permanent`: updates `capacity`. `type` is always coerced to `Available`, and `remainingCapacity` is silently dropped.",
+        "description": "Updates the general bookingAvailability info on the top level of the event with the given `eventId`.\n\nThe accepted properties and their behavior depend on the event's [calendarType](/models/event-calendarType.json):\n\n* `single` / `multiple`: updates the top-level `type` and `capacity`. The `type` of every subEvent is also updated to match, unless that subEvent already has [remainingCapacity](../docs/entry-api/events/booking-availability.md#the-bookingavailability-property) set. Top-level `remainingCapacity` is not meaningful and is rejected.\n* `periodic`: updates `capacity` and `remainingCapacity`. `type` is always coerced to `Available`.\n* `permanent`: updates `capacity`. `type` is always coerced to `Available`. Sending `remainingCapacity` returns HTTP 400.",
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
> Re-opens [#540](https://github.com/cultuurnet/apidocs/pull/540), which was auto-closed when the branch was renamed.

## Summary

- Adds an optional top-level `remainingCapacity` property to `event.bookingAvailability`, reusing `common-bookingAvailability-remainingCapacity.json` (already referenced by `event-subEvent-bookingAvailability.json`). The change cascades to `PUT /events/{eventId}/booking-availability`, `PUT /events/{eventId}/calendar`, and `PUT /events/{eventId}` via existing `$ref` chains.
- Keeps `type` required; `remainingCapacity` is optional.
- Updates the operation description on `PUT /events/{eventId}/booking-availability` and the `docs/entry-api/events/booking-availability.md` guide to spell out the per-`calendarType` semantics (the previous "you cannot update periodic/permanent" claim is gone).
- Updates the 400 example on the same operation to reflect the new error condition: `remainingCapacity` on a `permanent` event.

## Wanted behavior per calendarType

- `single` / `multiple`: top-level `type` and `capacity` accepted; top-level `remainingCapacity` rejected (not meaningful).
- `periodic`: `capacity` and `remainingCapacity` accepted; `type` is coerced to `Available`.
- `permanent`: `capacity` accepted; `type` is coerced to `Available`; `remainingCapacity` returns HTTP 400.

`place-bookingAvailability.json` is intentionally untouched: out of scope for now.