### PR TITLE
Restore childrenOnly as valid audienceType enum value

### DIFF
--- a/projects/uitdatabank/models/event-audience.json
+++ b/projects/uitdatabank/models/event-audience.json
@@ -19,7 +19,8 @@
       "enum": [
         "everyone",
         "members",
-        "education"
+        "education",
+        "childrenOnly"
       ],
       "description": "Indicates whether the event or place is accessible to `everyone`, `members` only or `education` only."
     }


### PR DESCRIPTION
## Summary

Re-adds `childrenOnly` to the `audienceType` enum in `event-audience.json`.

[PR #534](https://github.com/cultuurnet/apidocs/pull/534) removed `childrenOnly` from the enum in favor of a dedicated boolean property, but the corresponding code change has not been rolled out yet. Restoring the enum value keeps the schema aligned with what the API currently accepts.

Schema-only change — no further documentation updates.

## Test plan
- [ ] Verify schema validates payloads with `audienceType: childrenOnly`