### PR TITLE
III-7134 clarify toplevel capacity docs

### DIFF
--- a/projects/uitdatabank/docs/entry-api/events/booking-availability.md
+++ b/projects/uitdatabank/docs/entry-api/events/booking-availability.md
@@ -52,6 +52,8 @@ The booking availability of an event can include an optional `capacity` property
 
 All properties (`type`, `capacity`, and `remainingCapacity`) are optional and can be combined in any way.
 
+> **Capacity is only supported for events with calendarType `single` or `multiple`.** These events have concrete dates (`subEvent`), so a total and remaining number of seats/tickets is meaningful per date. Events with calendarType `periodic` or `permanent` do **not** support `capacity` — see [calendarType periodic/permanent](#calendartype-periodicpermanent) below. (For places, which always have calendarType `periodic` or `permanent`, capacity works differently — see the [place booking availability guide](../places/booking-availability.md).)
+
 When the event has calendarType `single` or `multiple`, the objects inside its `subEvent` property will also automatically get the same `bookingAvailability` property, except when sending `remainingCapacity`, in which case this field will overwrite the availibility type on each `subEvent`..
 
 For example on an event with multiple dates:
@@ -166,3 +168,5 @@ Events with calendarType `periodic` and `permanent` span a larger period and hav
 Because they do not have a `subEvent` property with specific dates, it is impossible to share their booking availability for certain dates at this moment.
 
 It is also not possible to change their top-level booking availability, because it is unlikely that such a long-running event is ever completely booked (especially in the case of permanent events).
+
+For the same reason, **`capacity` is not supported for events with calendarType `periodic` or `permanent`**. Capacity can only be set on events with calendarType `single` or `multiple` (per `subEvent`, as described above).

--- a/projects/uitdatabank/docs/entry-api/places/booking-availability.md
+++ b/projects/uitdatabank/docs/entry-api/places/booking-availability.md
@@ -8,6 +8,8 @@ However, you can optionally report the total capacity of a place using the `capa
 |------------|---|---|
 | `capacity` | integer ≥ 0 | Total number of seats or tickets at this place |
 
+Places always have calendarType `periodic` or `permanent` (see [calendar info](../shared/calendar-info.md)), and `capacity` can be set for both. Unlike events, a place has no `subEvent` dates, so `capacity` is reported once at the top level for the place as a whole. (For events, capacity works only for calendarType `single` or `multiple` — see the [event booking availability guide](../events/booking-availability.md).)
+
 ## Example
 
 ```json


### PR DESCRIPTION
### Added

Documents which calendar types support the top-level capacity property, which was previously left implicit:                                                                                                                                      
                                                                                                                                                                                                                                                   
  - Events (booking-availability.md): capacity is only supported for calendarType single/multiple (per subEvent). Added an explicit note in the periodic/permanent section stating capacity is not supported there.                                
  - Places (booking-availability.md): clarified that places always have calendarType periodic/permanent and capacity applies to both, reported once at the top level (no subEvent).                                                                
                                                                                                                                                                                                                                                   
---

Ticket: https://jira.uitdatabank.be/browse/III-7134 