### PR TITLE
III-7324/bookinginfo-removal-subevent-examples

### DIFF
--- a/projects/release-notes/docs/uitdatabank/2026.md
+++ b/projects/release-notes/docs/uitdatabank/2026.md
@@ -11,7 +11,6 @@ These BOA-features are currently being tested and are under active development. 
 * Introduction of `openingHoursAdjustedDays` on events and places. Integrators can declare adjusted opening hours for specific periods (start date, end date, opening hours, optional translated description). Validated for overlap and for falling within the calendar range.
 * Introduction of `faq` items on events. Integrators can manage FAQs with the new endpoint `PUT /events/{id}/faq` and include `faq` in the event `POST` / `PUT` body.
 * Introduction of `capacity` and `remainingCapacity` on `subEvent.bookingAvailability`.
-* Introduction of `bookingInfo` on subEvents.
 * Introduction of `childcare` times. For events with a `single` or `multiple` calendar, `childcare` can be set per subEvent. For events with a `periodic` or `permanent` calendar, `childcare` can be set per `openingHours` item. Childcare start must be before the event/opening time and childcare end must be after the event/closing time.
 * Introduction of `openingHoursClosedDays` on events and places, to declare exceptional closed periods on top of the regular calendar.
 * New boolean field `childrenOnly` on events, indicating an event aimed specifically at children.

--- a/projects/uitdatabank/docs/entry-api/events/create-boa.md
+++ b/projects/uitdatabank/docs/entry-api/events/create-boa.md
@@ -20,7 +20,6 @@ To ensure parents and children easily find the right activities, data quality is
 | Full schedule | `PUT /events/{eventId}/calendar` | Parents plan full days. Explicitly pass before- and after-school care hours ([`childcare`](../shared/calendar-info.md#childcare-times-events-only)), [adjusted opening hours](../shared/calendar-info.md#adjusted-opening-hours-periodicpermanent), and [specific holiday closures](../shared/calendar-info.md#adjusted-closed-days-periodicpermanent). | single, multiple, periodic, permanent | ✅ |
 | Overnight stays | `PATCH /events/{eventId}/subEvents` | For camps, clearly specify if the activity includes an [overnight stay](../shared/calendar-info.md#overnight-events-only-singlemultiple) (`overnight`). | single, multiple | ✅ |
 | Departure places | `PUT /events/{eventId}/departurePlaces` | If guided transport is provided from a school or another care location to the activity, [link these locations](/docs/uitdatabank/entry-api/reference/operations/update-a-event-departure-places). | all (requires `childrenOnly: true`) | ✅ |
-| Booking info | `PATCH /events/{eventId}/subEvents` | Provide [per-date booking contacts](../shared/booking-and-contact-info.md#bookinginfo) on subEvents so parents know where to register for each occurrence. | single, multiple | ❌ |
 
 ## Request body example
 
@@ -53,13 +52,6 @@ Example for a BOA event (calendarType `single`) with `childrenOnly` set to `true
       "bookingAvailability": {
         "capacity": 30,
         "remainingCapacity": 12
-      },
-      "bookingInfo": {
-        "url": "https://example.com/inschrijven",
-        "urlLabel": {
-          "nl": "Schrijf je in"
-        },
-        "email": "info@example.be"
       }
     }
   ],


### PR DESCRIPTION
Removes all documentation and example references to `bookingInfo` on subEvents.

This PR deliberately **leaves the endpoint JSON schemas untouched** (`event-subEvent.json`, `event-subEvent-put.json`, `event-subEvent-patch.json`). The JSON schemas are used to validate the code, and the backend code has not been changed yet and I am afraid removing them now would break validation. T

## Ticket
https://jira.publiq.be/browse/III-7324