### PR TITLE
III-7324/bookinginfo-removal-subevent-json-schema

### DIFF
--- a/projects/uitdatabank/models/event-subEvent-patch.json
+++ b/projects/uitdatabank/models/event-subEvent-patch.json
@@ -139,9 +139,6 @@
           }
         ]
       },
-      "bookingInfo": {
-        "$ref": "./event-bookingInfo.json"
-      },
       "overnight": {
         "type": "boolean",
         "description": "Indicates whether this occurrence involves an overnight stay. Only accepted when the event has a term with id `0.57.0.0.0` (\"Kamp of vakantie\"). Defaults to `false` when omitted. Automatically reset to `false` when term `0.57.0.0.0` is removed from the event.",

--- a/projects/uitdatabank/models/event-subEvent-put.json
+++ b/projects/uitdatabank/models/event-subEvent-put.json
@@ -71,9 +71,6 @@
       "bookingAvailability": {
         "$ref": "./event-bookingAvailability.json"
       },
-      "bookingInfo": {
-        "$ref": "./event-bookingInfo.json"
-      },
       "overnight": {
         "type": "boolean",
         "description": "Indicates whether this occurrence involves an overnight stay. Only accepted when the event has a term with id `0.57.0.0.0` (\"Kamp of vakantie\"). Defaults to `false` when omitted. Automatically reset to `false` when term `0.57.0.0.0` is removed from the event.",

--- a/projects/uitdatabank/models/event-subEvent.json
+++ b/projects/uitdatabank/models/event-subEvent.json
@@ -80,9 +80,6 @@
       "bookingAvailability": {
         "$ref": "./event-subEvent-bookingAvailability.json"
       },
-      "bookingInfo": {
-        "$ref": "./event-bookingInfo.json"
-      },
       "overnight": {
         "type": "boolean",
         "description": "Indicates whether this occurrence involves an overnight stay. Only present in the response when `true`. Only applicable when the event has a term with id `0.57.0.0.0` (\"Kamp of vakantie\").",


### PR DESCRIPTION
Removes the `bookingInfo` property from the subEvent endpoint JSON schemas.

⚠️ **Merge order:** this is the follow-up to `III-7324/bookinginfo-removal-subevent-examples` (docs & examples). Because the JSON schemas are used to validate the code and the backend code has not been changed yet, this schema removal should only be merged/deployed once the code no longer relies on `bookingInfo` on subEvents — merging it too early would break validation.

## Ticket
https://jira.publiq.be/browse/III-7324