### PR TITLE
III-7215 document hasChildcare search filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,20 @@ Images go in `assets/images/` with slug-style filenames.
 
 ---
 
+## Adding a Search API Filter
+
+When adding a new search filter parameter, update **all three** of the following:
+
+1. **Documentation file** — create `projects/uitdatabank/docs/search-api/filters/<name>.md` following the pattern of existing filters (intro, `## Using the <param> parameter`, applicable endpoints, possible values, examples).
+2. **toc.json** — add an entry under the `"Common filters"` group in `projects/uitdatabank/toc.json`.
+3. **OpenAPI spec** — in `projects/uitdatabank/reference/search.json`:
+   - Add a component definition under `components.parameters` (use existing boolean params like `uitpas` or `allAges` as a template).
+   - Add a `$ref` to it in the `parameters` array of each applicable endpoint (`/events`, `/offers`, `/places`).
+
+**Endpoint scope:** Not all parameters apply to all endpoints. Childcare, for example, is events-only and belongs on `/events` and `/offers` but not `/places`. Check the Entry API docs to confirm scope before wiring up refs.
+
+---
+
 ## Keeping Examples Up to Date
 
 Whenever a new property is added to a schema, **all `examples` arrays in related schema files must be updated** to include the new property. This ensures examples stay accurate and useful for integrators.

--- a/projects/uitdatabank/docs/search-api/filters/childcare.md
+++ b/projects/uitdatabank/docs/search-api/filters/childcare.md
@@ -1,0 +1,48 @@
+# Filtering by childcare
+
+Events in UiTdatabank can optionally provide [childcare times](../../entry-api/shared/calendar-info.md#childcare-times-events-only): a service offered before and/or after the activity itself. With the `hasChildcare` parameter you can filter events based on whether or not childcare is available.
+
+## Using the hasChildcare parameter
+
+**Applicable on endpoints**
+
+`/events` `/offers`
+
+**Possible values**
+
+* `true`: only return events that have a `childcare` range configured on at least one sub-event (for `single`/`multiple` calendar types) or at least one opening hours entry (for `periodic`/`permanent` calendar types).
+* `false`: only return events that have no `childcare` configured on any sub-event or opening hours entry.
+
+When the parameter is omitted, all events are returned regardless of whether childcare is configured.
+
+**Examples**
+
+Retrieve all events that offer childcare:
+
+```http
+GET /events/?hasChildcare=true
+```
+
+Retrieve all events in Ghent that offer childcare:
+
+```http
+GET /events/?postalCode=9000&hasChildcare=true
+```
+
+Retrieve all events that do not offer childcare:
+
+```http
+GET /events/?hasChildcare=false
+```
+
+## Combining with dateRange
+
+When `hasChildcare` is combined with a [`dateRange`](./datetime.md) filter, the childcare check is scoped to the matching period: the API checks whether childcare is configured on the sub-events or opening hours that fall within that date range, not on the event as a whole.
+
+> The `dateRange` filter itself still matches against the actual start and end times of the activity — childcare hours never influence which events are considered to fall within a date range.
+
+Retrieve all events in May 2025 that offer childcare during that period:
+
+```http
+GET /events/?hasChildcare=true&dateRange[start]=2025-05-01T00:00:00%2B02:00&dateRange[end]=2025-05-31T23:59:59%2B02:00
+```

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -293,6 +293,9 @@
             "$ref": "#/components/parameters/uitpas"
           },
           {
+            "$ref": "#/components/parameters/hasChildcare"
+          },
+          {
             "$ref": "#/components/parameters/hasVideos"
           },
           {
@@ -726,6 +729,9 @@
           },
           {
             "$ref": "#/components/parameters/uitpas"
+          },
+          {
+            "$ref": "#/components/parameters/hasChildcare"
           },
           {
             "$ref": "#/components/parameters/hasVideos"
@@ -2360,6 +2366,14 @@
         "in": "query",
         "name": "uitpas",
         "description": "Returns only results that are related to UiTPAS if set to `true`. Returns only results that are not related to UiTPAS if set to `false`."
+      },
+      "hasChildcare": {
+        "schema": {
+          "type": "boolean"
+        },
+        "in": "query",
+        "name": "hasChildcare",
+        "description": "Returns only events that have childcare configured on at least one sub-event or opening hours entry if set to `true`. Returns only events that have no childcare configured if set to `false`. When combined with `dateRange`, the childcare check is scoped to the matching period."
       },
       "hasVideos": {
         "schema": {

--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -396,6 +396,12 @@
             },
             {
               "type": "item",
+              "title": "Filtering by childcare",
+              "uri": "/docs/search-api/filters/childcare.md",
+              "slug": "search-api/filters/filtering-by-childcare"
+            },
+            {
+              "type": "item",
               "title": "Filtering by labels",
               "uri": "/docs/search-api/filters/labels.md",
               "slug": "search-api/filters/filtering-by-labels"


### PR DESCRIPTION
## Summary

- Adds `docs/search-api/filters/childcare.md` documenting the new `hasChildcare` boolean query parameter
- Links the new page in `toc.json` under Common filters (after "Filtering by date & time")

## Live preview
https://publiq.stoplight.io/docs/uitdatabank/branches/III-7215%2Fchildcare-filter/search-api/filters/filtering-by-childcare


## Ticket
https://jira.publiq.be/browse/III-7215