### PR TITLE
[Small fix] III-7215 fix date filter parameter name in childcare docs

### DIFF
--- a/projects/uitdatabank/docs/search-api/filters/childcare.md
+++ b/projects/uitdatabank/docs/search-api/filters/childcare.md
@@ -35,14 +35,14 @@ Retrieve all events that do not offer childcare:
 GET /events/?hasChildcare=false
 ```
 
-## Combining with dateRange
+## Combining with a date filter
 
-When `hasChildcare` is combined with a [`dateRange`](./datetime.md) filter, the childcare check is scoped to the matching period: the API checks whether childcare is configured on the sub-events or opening hours that fall within that date range, not on the event as a whole.
+When `hasChildcare` is combined with a date filter (`dateFrom`/`dateTo` URL parameters, or the `dateRange` advanced query field), the childcare check is scoped to the matching period: the API checks whether childcare is configured on the sub-events or opening hours that fall within that date range, not on the event as a whole.
 
-> The `dateRange` filter itself still matches against the actual start and end times of the activity — childcare hours never influence which events are considered to fall within a date range.
+> The date filter itself still matches against the actual start and end times of the activity — childcare hours never influence which events are considered to fall within a date range.
 
 Retrieve all events in May 2025 that offer childcare during that period:
 
 ```http
-GET /events/?hasChildcare=true&dateRange[start]=2025-05-01T00:00:00%2B02:00&dateRange[end]=2025-05-31T23:59:59%2B02:00
+GET /events/?hasChildcare=true&dateFrom=2025-05-01T00:00:00%2B02:00&dateTo=2025-05-31T23:59:59%2B02:00
 ```

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -2373,7 +2373,7 @@
         },
         "in": "query",
         "name": "hasChildcare",
-        "description": "Returns only events that have childcare configured on at least one sub-event or opening hours entry if set to `true`. Returns only events that have no childcare configured if set to `false`. When combined with `dateRange`, the childcare check is scoped to the matching period."
+        "description": "Returns only events that have childcare configured on at least one sub-event or opening hours entry if set to `true`. Returns only events that have no childcare configured if set to `false`. When combined with `dateFrom`/`dateTo` or the `dateRange` advanced query field, the childcare check is scoped to the matching period."
       },
       "hasVideos": {
         "schema": {


### PR DESCRIPTION

I mixed up how to filter on daterange. I used dateRange, but this is an advanced query field (?q=dateRange:[...]), not a URL parameter. Used dateFrom/dateTo in examples and descriptions instead.

---

Ticket: https://jira.uitdatabank.be/browse/III-7215
