### PR TITLE
III-7190 document matchingBirthdateRanges response field

### DIFF
--- a/projects/uitdatabank/docs/search-api/filters/birthdate-range.md
+++ b/projects/uitdatabank/docs/search-api/filters/birthdate-range.md
@@ -16,3 +16,48 @@ or the `typicalAgeRange` falls within the birthdateRange at the moment the query
 ```http
 GET /events/?birthdateRangeFrom=2020-01-01&birthdateRangeTo=2020-12-31
 ```
+
+## The matchingBirthdateRanges response field
+
+When a query includes `birthdateRangeFrom`/`birthdateRangeTo`, the response includes a top-level `matchingBirthdateRanges` array. It contains one entry for the queried range, listing the `@id` of every result in the resultset that matches it. This is useful for showing a parent which of their children's birthdates a given result is suitable for.
+
+`matchingBirthdateRanges` is omitted from the response when the query does not include `birthdateRangeFrom`/`birthdateRangeTo`.
+
+**Example**
+
+Request:
+
+```http
+GET /events/?birthdateRangeFrom=2020-01-01&birthdateRangeTo=2022-12-31
+```
+
+Response:
+
+```json
+{
+  "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+  "@type": "PagedCollection",
+  "itemsPerPage": 30,
+  "totalItems": 2,
+  "member": [
+    {
+      "@id": "https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45",
+      "@type": "Event"
+    },
+    {
+      "@id": "https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1",
+      "@type": "Event"
+    }
+  ],
+  "matchingBirthdateRanges": [
+    {
+      "from": "2020-01-01",
+      "to": "2022-12-31",
+      "matches": [
+        "https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45",
+        "https://io.uitdatabank.be/events/557d0ddc-efc9-42b3-934b-9f88b0945ab1"
+      ]
+    }
+  ]
+}
+```

--- a/projects/uitdatabank/models/common-matchingBirthdateRanges.json
+++ b/projects/uitdatabank/models/common-matchingBirthdateRanges.json
@@ -1,0 +1,42 @@
+{
+  "title": "matchingBirthdateRanges",
+  "description": "Present when the query includes the `birthdateRangeFrom`/`birthdateRangeTo` parameters. Contains one entry for the queried birthdate range, listing the `@id` of every result in the resultset that matches it. Lets an integrator show which queried range (e.g. a specific child's birthdate) each result qualifies for.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "from": {
+        "type": "string",
+        "format": "date",
+        "description": "The `birthdateRangeFrom` value that was queried.",
+        "example": "2020-01-01"
+      },
+      "to": {
+        "type": "string",
+        "format": "date",
+        "description": "The `birthdateRangeTo` value that was queried.",
+        "example": "2022-12-31"
+      },
+      "matches": {
+        "type": "array",
+        "description": "The `@id` of every result in the resultset that matches this birthdate range.",
+        "items": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "required": ["from", "to", "matches"]
+  },
+  "examples": [
+    [
+      {
+        "from": "2020-01-01",
+        "to": "2022-12-31",
+        "matches": [
+          "https://io.uitdatabank.be/events/d9a71b53-1756-4126-9926-a83f5dd84f45"
+        ]
+      }
+    ]
+  ]
+}

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -72,6 +72,9 @@
                           "$ref": "../models/common-facets.json"
                         }
                       }
+                    },
+                    "matchingBirthdateRanges": {
+                      "$ref": "../models/common-matchingBirthdateRanges.json"
                     }
                   },
                   "required": [
@@ -362,6 +365,9 @@
                           "$ref": "../models/common-facets.json"
                         }
                       }
+                    },
+                    "matchingBirthdateRanges": {
+                      "$ref": "../models/common-matchingBirthdateRanges.json"
                     }
                   },
                   "required": [


### PR DESCRIPTION
- Document the `matchingBirthdateRanges` top-level response field ([III-7190](https://jira.publiq.be/browse/III-7190)), returned on `/events` (GET and POST) when the query includes `birthdateRangeFrom`/`birthdateRangeTo`
- Add a "The matchingBirthdateRanges response field" section to `birthdate-range.md` with request/response examples
- Add `models/common-matchingBirthdateRanges.json` and reference it from the `/events` response schema in `search.json`

## Ticket
https://jira.publiq.be/browse/III-7190