### PR TITLE
III-7216 expose departurePlaces on the offers endpoint

### DIFF
--- a/projects/uitdatabank/docs/search-api/filters/departure-places.md
+++ b/projects/uitdatabank/docs/search-api/filters/departure-places.md
@@ -6,7 +6,7 @@ Use the `departurePlaces[]` URL parameter or the `departurePlaces` advanced quer
 
 **Applicable on endpoints**
 
-`/events`
+`/events` `/offers`
 
 **Possible values**
 

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -674,6 +674,9 @@
             "$ref": "#/components/parameters/locationId"
           },
           {
+            "$ref": "#/components/parameters/departurePlaces"
+          },
+          {
             "$ref": "#/components/parameters/organizerId"
           },
           {


### PR DESCRIPTION
## Changed
- The search backend already honors `departurePlaces` on `/offers`, not just `/events` — the OpenAPI spec and docs were understating what's supported.
- Adds the `departurePlaces` `$ref` to the `get-offers` operation in `search.json`.
- Updates `departure-places.md` to list `/events` and `/offers` as applicable endpoints.