### PR TITLE
III-7360 Update/revert the childrenOnly documentation to accurately reflect the current situation

### DIFF
--- a/projects/uitdatabank/docs/search-api/filters/children-only.md
+++ b/projects/uitdatabank/docs/search-api/filters/children-only.md
@@ -10,13 +10,12 @@ Events in UiTdatabank can optionally be marked as intended for [children only](/
 
 **Possible values**
 
-* `false`: (default) only return events that have `childrenOnly` set to `false` or not set at all.
+* `false`: only return events that have `childrenOnly` set to `false` or not set at all.
 * `true`: only return events that have `childrenOnly` set to `true`.
-* `*`: returns all events, with `childrenOnly` set to `false` or `true` (see our page about [disabling default filters](../filters/default-filters.md))
 
 When the parameter is omitted, only events that are NOT targeted towards "children only" are returned.
 
-> Note that when using `childrenOnly=true` or `childrenOnly=*`, you will always find events set to `childrenOnly: true` that have been created by *your* client. Events created by other users and set to `childrenOnly: true` are only returned if your account has been granted access by publiq. If you have a use case that requires broader access to events targeted towards children only, please contact us via [publiq.be/boa](https://publiq.be/boa).
+> Note that when using `childrenOnly=true`, you will always find events set to `childrenOnly: true` that have been created by *your* client. Events created by other users and set to `childrenOnly: true` are only returned if your account has been granted access by publiq. If you have a use case that requires broader access to events targeted towards children only, please contact us via [publiq.be/boa](https://publiq.be/boa).
 
 **Examples**
 
@@ -37,11 +36,3 @@ Retrieve all events that are not targeted at children only:
 ```http
 GET /events/?childrenOnly=false
 ```
-
-Retrieve all events that are targeted towards children only, AND other events
-
-```http
-GET /events/?childrenOnly=*
-```
-
-(See also [our page about disabling default filters](../filters/default-filters.md) for more info.)

--- a/projects/uitdatabank/docs/search-api/filters/default-filters.md
+++ b/projects/uitdatabank/docs/search-api/filters/default-filters.md
@@ -7,7 +7,6 @@ When searching for events, places, or offers the search API applies a couple of 
 * `availableTo`: only results that with an availableTo-date equal or bigger then the now-date are returned by default.
 * `addressCountry`: only results that are in Belgium are returned by default.
 * `audienceType`: only results that have an `audienceType` set to `everyone` are returned by default.
-* `childrenOnly`: only results that have `childrenOnly` set to `false` are returned by default.
 
 You can either disable these filters individually, or disable them all at once.
 
@@ -65,14 +64,6 @@ Disabling the default `audienceType` filter will also show results with audience
 
 ```
 GET /offers/?audienceType=*
-```
-
-### childrenOnly
-
-Disabling the default `childrenOnly` filter will also show results with `childrenOnly` set to `true`, as well as results with `childrenOnly` set to `false`.
-
-```
-GET /offers/?childrenOnly=*
 ```
 
 ## Disable multiple filters

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -2400,17 +2400,11 @@
       },
       "childrenOnly": {
         "schema": {
-          "type": "string",
-          "enum": [
-            "true",
-            "false",
-            "*"
-          ],
-          "default": "false"
+          "type": "boolean"
         },
         "in": "query",
         "name": "childrenOnly",
-        "description": "Returns only events that are targeted at children only, without parents or guardians, if set to `true`. Returns only events that are not targeted at children only if set to `false`. Returns either kind of event if set to `*`."
+        "description": "Returns only events that are targeted at children only, without parents or guardians, if set to `true`. Returns only events that are not targeted at children only if set to `false`."
       },
       "hasVideos": {
         "schema": {


### PR DESCRIPTION
### Fixed

- Documentated `childrenOnly` as a boolean with no default value, to reflect the current situation while we wait on clarification of III-7360 (#560 was merged too fast)

---

Ticket: https://jira.uitdatabank.be/browse/III-7360

⚠️ Ideally we merge this ASAP, and we can always revert this in context of III-7360 if it turns out we need to set the default to `false` after all
