### PR TITLE
Clarify that subEvent-specific filtering on `childcare` and `overnight` does not work with advanced queries + small fixes

### DIFF
--- a/projects/uitdatabank/docs/search-api/filters/childcare.md
+++ b/projects/uitdatabank/docs/search-api/filters/childcare.md
@@ -37,12 +37,16 @@ GET /events/?hasChildcare=false
 
 ## Combining with a date filter
 
-When `hasChildcare` is combined with a date filter (`dateFrom`/`dateTo` URL parameters, or the `dateRange` advanced query field), the childcare check is scoped to the matching period: the API checks whether childcare is configured on the sub-events or opening hours that fall within that date range, not on the event as a whole.
+When `hasChildcare` is combined with a date filter (`dateFrom`/`dateTo` URL parameters), the childcare check is scoped to the matching period: the API checks whether childcare is configured on the sub-events or opening hours that fall within that date range, not on the event as a whole.
 
 > The date filter itself still matches against the actual start and end times of the activity — childcare hours never influence which events are considered to fall within a date range.
 
-Retrieve all events in May 2025 that offer childcare during that period:
+Retrieve all events in May 2025 that offer childcare during that specific period:
 
 ```http
 GET /events/?hasChildcare=true&dateFrom=2025-05-01T00:00:00%2B02:00&dateTo=2025-05-31T23:59:59%2B02:00
 ```
+
+<!-- theme: warning -->
+
+> While you can also use on childcare and/or dates in advanced queries, this specific logic of checking whether the event has childcare during the specified date range does NOT work in advanced queries (`q` URL parameter) due to how they are parsed differently.

--- a/projects/uitdatabank/docs/search-api/filters/childcare.md
+++ b/projects/uitdatabank/docs/search-api/filters/childcare.md
@@ -49,4 +49,4 @@ GET /events/?hasChildcare=true&dateFrom=2025-05-01T00:00:00%2B02:00&dateTo=2025-
 
 <!-- theme: warning -->
 
-> While you can also use on childcare and/or dates in advanced queries, this specific logic of checking whether the event has childcare during the specified date range does NOT work in advanced queries (`q` URL parameter) due to how they are parsed differently.
+> While you can also filter on `childcare` and/or `dateRange` in advanced queries, this specific logic of checking whether the event has childcare during the specified date range does NOT work in advanced queries (`q` URL parameter) due to how they are parsed differently.

--- a/projects/uitdatabank/docs/search-api/filters/overnight.md
+++ b/projects/uitdatabank/docs/search-api/filters/overnight.md
@@ -2,7 +2,7 @@
 
 ## hasOvernight
 
-Use the `hasOvernight` URL parameter to filter events based on whether they offer overnight acconodation.
+Use the `hasOvernight` URL parameter to filter events based on whether they offer overnight accomodation.
 
 **Applicable on endpoints**
 

--- a/projects/uitdatabank/docs/search-api/filters/overnight.md
+++ b/projects/uitdatabank/docs/search-api/filters/overnight.md
@@ -2,7 +2,7 @@
 
 ## hasOvernight
 
-Use the `hasOvernight` URL parameter to filter events based on whether they involve an overnight stay.
+Use the `hasOvernight` URL parameter to filter events based on whether they offer overnight acconodation.
 
 **Applicable on endpoints**
 
@@ -18,34 +18,44 @@ Use the `hasOvernight` URL parameter to filter events based on whether they invo
 * `false`: only returns events that have no sub-event with `overnight: true`
 * Omitting the parameter returns all events regardless of their overnight value
 
-An event is considered to have overnight if **at least one** of its sub-events is marked as overnight. An event where only some sub-events are overnight still matches `hasOvernight=true`.
+An event is considered to have overnight accomodation if **at least one** of its sub-events is marked as `overnight: true`. An event where only some sub-events have `overnight: true` still matches `hasOvernight=true` unless combined with a date filter (see below).
 
 Events with a `periodic` or `permanent` calendarType have no explicit sub-events and are always indexed as `overnight: false`. They will never match `hasOvernight=true`.
 
-`hasOvernight` does not affect the date range of an event. An overnight event's matched date window is still determined by the actual `startDate` and `endDate` of its sub-events.
-
 **Examples**
 
-Retrieve all events that involve an overnight stay:
+Retrieve all events that offer overnight accomodation:
 
 ```http
 GET /events/?hasOvernight=true
 ```
 
-Retrieve all events that do not involve an overnight stay:
+Retrieve all events that do not offer overnight accomodation:
 
 ```http
 GET /events/?hasOvernight=false
 ```
 
-Combining with a date filter to find overnight events in a given period:
+Combining with a date filter to find events with overnight accomodation in a given period:
 
 ```http
 GET /events/?hasOvernight=true&dateFrom=2026-07-01T00:00:00+02:00&dateTo=2026-08-31T23:59:59+02:00
 ```
 
-**Interaction with date filters**
+## Combining with a date filter
 
 When combined with `dateFrom`/`dateTo`, `hasOvernight` is evaluated against the sub-events that fall within the requested date range — not against the event as a whole. An event with overnight sub-events outside the searched period will not match `hasOvernight=true` for that period.
 
 For example: an event with two weeks of sub-events where only week 2 has overnight sub-events will not match `hasOvernight=true` when searching exclusively within week 1.
+
+When `hasOvernight` is combined with a date filter (`dateFrom`/`dateTo` URL parameters), the overnight filter is scoped to the matching period: the API checks whether `overnight` is enabled/disabled on the sub-events or opening hours that fall within that date range, not on the event as a whole.
+
+Retrieve all events in May 2025 that offer overnight accomodation during that specific period:
+
+```http
+GET /events/?hasOvernight=true&dateFrom=2025-05-01T00:00:00%2B02:00&dateTo=2025-05-31T23:59:59%2B02:00
+```
+
+<!-- theme: warning -->
+
+> While you can also filter on `overnight` and/or `dateRange` in advanced queries, this specific logic of checking whether the event has overnight accomodation during the specified date range does NOT work in advanced queries (`q` URL parameter) due to how they are parsed differently.


### PR DESCRIPTION
### Fixed

- Removed factually incorrect reference that `hasChildcare` can be combined with `dateRange` in advanced queries
- Clarified that the combination of `hasChildcare` and `dateFrom`/`dateTo` only works as explicit URL parameters, not in advanced queries since they are parsed differently
- Clarified that the combination of `hasOvernight` and `dateFrom`/`dateTo` only works as explicit URL parameters, not in advanced queries since they are parsed differently
- Removed copy/paste error about `hasOvernight` not influencing the start and end date of events (copied from childcare I assume)
