### PR TITLE
Auto-run Claude review when a PR is opened

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,13 +4,13 @@ on:
   issue_comment:
     types: [created]
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,10 +3,14 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened]
 
 jobs:
   claude:
-    if: contains(github.event.comment.body, '@claude')
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### Changed

- Added a `pull_request: [opened, ready_for_review]` trigger so new PRs are reviewed by Claude automatically.
- Draft PRs are skipped (`github.event.pull_request.draft == false`); the review runs as soon as a draft is marked ready for review.
- Kept the manual `@claude` comment trigger, which stays useful for re-review after extra commits.
- Updated the job `if` to branch on `github.event_name`, since a `pull_request` event has no `comment.body` (without this, the job would silently skip on PR events).

### Why

Some naming/convention issues slipped through recently because Claude wasn't manually triggered on those PRs (e.g. #557, #558). Reviewing on creation makes the check consistent instead of relying on someone remembering to comment.

Drafts are excluded because work in progress isn't ready for review yet — team consensus.

### Notes

- Scoped to `opened` and `ready_for_review` to keep cost down; re-review on later commits is still available via a manual `@claude` comment.
- Secrets are available because PRs come from branches in this repo (not forks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)