### PR TITLE
III-7246 Document recurringOnDayOfWeek url param

### DIFF
--- a/projects/release-notes/docs/uitdatabank/2026.md
+++ b/projects/release-notes/docs/uitdatabank/2026.md
@@ -14,6 +14,7 @@ These BOA-features are currently being tested and are under active development. 
 * Introduction of `childcare` times. For events with a `single` or `multiple` calendar, `childcare` can be set per subEvent. For events with a `periodic` or `permanent` calendar, `childcare` can be set per `openingHours` item. Childcare start must be before the event/opening time and childcare end must be after the event/closing time.
 * Introduction of `openingHoursClosedDays` on events and places, to declare exceptional closed periods on top of the regular calendar.
 * New boolean field `childrenOnly` on events, indicating an event aimed specifically at children.
+* Introduction of the `recurringOnDayOfWeek` filter in Search API, available as URL parameter and as advanced query field, e.g. `?recurringOnDayOfWeek=friday,saturday`. Only events that recur on the given weekday are returned, events on a single date are never matched.
 * Introduction of `birthdateRange` on events. Integrators can manage the birth-date range of the target audience with the new endpoints `PUT /events/{id}/birthdate-range` and `DELETE /events/{id}/birthdate-range`.
 
 ## July

--- a/projects/uitdatabank/docs/search-api/advanced/advanced-queries.md
+++ b/projects/uitdatabank/docs/search-api/advanced/advanced-queries.md
@@ -873,6 +873,34 @@ Retrieve all events with a price equal to or higher than 50 EUR:
 GET /events/?q=priceRange:[50 TO *]
 ```
 
+### recurringOnDayOfWeek
+
+With the `recurringOnDayOfWeek` field you can look for results that recur on a given weekday, for example a market every Wednesday. Events that take place on a single date are never matched.
+
+For an in-depth understanding of the `recurringOnDayOfWeek` field we advise to read [our guide](../filters/recurring-day-of-week.md).
+
+**Applicable on endpoints**
+
+`/events` `/places` `/offers`
+
+**Possible values**
+
+`monday` `tuesday` `wednesday` `thursday` `friday` `saturday` `sunday`
+
+**Examples**
+
+Search for all events that recur on Wednesdays:
+
+```
+GET /events/?q=recurringOnDayOfWeek:wednesday
+```
+
+Unlike the URL parameter, which always combines multiple weekdays as an OR, advanced queries allow you to combine weekdays with other boolean operators. Search for all events that recur on both Saturday and Sunday:
+
+```
+GET /events/?q=recurringOnDayOfWeek:(saturday AND sunday)
+```
+
 ### regions
 
 publiq has a list of pre-indexed geographical shapes that represent the administrative state of Belgium. The geographical coördinates of events and places are then matched with pre-indexed geographical shapes for:

--- a/projects/uitdatabank/docs/search-api/filters/recurring-day-of-week.md
+++ b/projects/uitdatabank/docs/search-api/filters/recurring-day-of-week.md
@@ -1,0 +1,61 @@
+# Filtering on recurring day of week
+
+Some events and places in UiTdatabank recur on a fixed weekday: a market every Wednesday, a guided tour every Saturday and Sunday. With the `recurringOnDayOfWeek` parameter you can find them by weekday.
+
+Note the word "recurring": only events that take place on a given weekday often enough to be considered recurring are returned. An event that happens on one single date is never matched. To search for events on a specific date, use the [date filters](datetime.md#filtering-on-date) instead.
+
+## Using the recurringOnDayOfWeek parameter
+
+`recurringOnDayOfWeek` is available as both an URL parameter and as an advanced query field:
+* URL parameter: `recurringOnDayOfWeek`
+* Advanced query field: `recurringOnDayOfWeek`
+
+**Applicable on endpoints**
+
+`/events` `/places` `/offers`
+
+**Possible values**
+
+`monday` `tuesday` `wednesday` `thursday` `friday` `saturday` `sunday`
+
+Any other value is rejected with a `400` status code, as described in the [errors guide](../../errors.md).
+
+Multiple comma-separated values are combined as an OR: events that recur on at least one of the given weekdays are returned.
+
+**Examples**
+
+Retrieve all events that recur on Wednesdays:
+
+```http
+GET /events/?recurringOnDayOfWeek=wednesday
+```
+
+Retrieve all events that recur on a Friday, Saturday or Sunday:
+
+```http
+GET /events/?recurringOnDayOfWeek=friday,saturday,sunday
+```
+
+Retrieve all events in Ghent that recur on Saturdays:
+
+```http
+GET /events/?postalCode=9000&recurringOnDayOfWeek=saturday
+```
+
+## How the weekdays are determined
+
+Which weekdays a result recurs on depends on its [calendarType](datetime.md#filtering-on-calendartype):
+
+* `periodic` and `permanent`: the weekdays are taken from `openingHours[].dayOfWeek`. An event or place that is open every Wednesday matches `recurringOnDayOfWeek=wednesday`. Places always have one of these two calendarTypes, so they are always matched on their opening hours.
+* `multiple`: the weekday of each sub-event is derived from its `startDate` and `endDate`. A sub-event that spans several days, for example Friday until Sunday, counts for every weekday in that range. All sub-events combined determine the weekdays the event matches on.
+* `single`: never matched, since an event on a single date does not recur.
+
+## Combining weekdays in advanced queries
+
+The `recurringOnDayOfWeek` URL parameter always combines multiple weekdays as an OR. With the `q` parameter you can use [advanced queries](../advanced/advanced-queries.md#recurringondayofweek) to combine weekdays differently.
+
+Retrieve all events that recur on both Saturday and Sunday, so events that recur on only one of both weekend days are excluded:
+
+```http
+GET /events/?q=recurringOnDayOfWeek:(saturday AND sunday)
+```

--- a/projects/uitdatabank/reference/search.json
+++ b/projects/uitdatabank/reference/search.json
@@ -200,6 +200,9 @@
             "$ref": "#/components/parameters/localTimeTo"
           },
           {
+            "$ref": "#/components/parameters/recurringOnDayOfWeek"
+          },
+          {
             "$ref": "#/components/parameters/embed"
           },
           {
@@ -648,6 +651,9 @@
           },
           {
             "$ref": "#/components/parameters/localTimeTo"
+          },
+          {
+            "$ref": "#/components/parameters/recurringOnDayOfWeek"
           },
           {
             "$ref": "#/components/parameters/embed"
@@ -1405,6 +1411,9 @@
             "$ref": "#/components/parameters/localTimeTo"
           },
           {
+            "$ref": "#/components/parameters/recurringOnDayOfWeek"
+          },
+          {
             "$ref": "#/components/parameters/facets"
           },
           {
@@ -1934,6 +1943,28 @@
         "in": "query",
         "name": "calendarType",
         "description": "Returns only results with the given enum value as their calendarType. Accepts multiple comma-separated values to return results that have one of the given calendar types. [Here is a detailed guide](./entry-api/shared/calendar-info#calendartype) with more information."
+      },
+      "recurringOnDayOfWeek": {
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        },
+        "style": "form",
+        "explode": false,
+        "in": "query",
+        "name": "recurringOnDayOfWeek",
+        "description": "Returns only results that recur on the given weekday. For results with a `periodic` or `permanent` calendarType the weekdays are taken from `openingHours[].dayOfWeek`. For events with a `multiple` calendarType the weekdays are derived from the `startDate` and `endDate` of the sub-events. Events with a `single` calendarType are never returned. Accepts multiple comma-separated values to return results that recur on one of the given weekdays."
       },
       "createdFrom": {
         "schema": {

--- a/projects/uitdatabank/toc.json
+++ b/projects/uitdatabank/toc.json
@@ -396,6 +396,12 @@
             },
             {
               "type": "item",
+              "title": "Filtering by recurring day of week",
+              "uri": "/docs/search-api/filters/recurring-day-of-week.md",
+              "slug": "search-api/filters/filtering-by-recurring-day-of-week"
+            },
+            {
+              "type": "item",
               "title": "Filtering by childcare",
               "uri": "/docs/search-api/filters/childcare.md",
               "slug": "search-api/filters/filtering-by-childcare"


### PR DESCRIPTION
  ### Added

  - Guide "Filtering on recurring day of week", documenting the new `recurringOnDayOfWeek` Search API filter, listed under Common filters in the toc.
  - `recurringOnDayOfWeek` section in the advanced queries reference, with a plain example and one showing the `AND` combination the URL parameter cannot express.
  - `recurringOnDayOfWeek` parameter in the Search API OpenAPI spec, on `/events`, `/offers` and `/places`.
  - Release note for the filter under the 2026 upcoming features.

  ---

  Ticket: https://jira.uitdatabank.be/browse/III-7246